### PR TITLE
fix(server): fall back to default grouping on empty fingerprint

### DIFF
--- a/apps/server/src/services/grouping.rs
+++ b/apps/server/src/services/grouping.rs
@@ -9,9 +9,12 @@ pub fn calculate_grouping_key(event_data: &Value) -> String {
     let (calculated_type, calculated_value) = get_type_and_value(event_data);
     let transaction = get_transaction(event_data);
 
-    // Check for custom fingerprint
+    // Check for custom fingerprint. An empty fingerprint (sent as `[]` by
+    // sentry-ruby, or left empty after Relay drops null/array/object parts)
+    // means "no custom fingerprint" and falls back to default grouping, as
+    // in Sentry (`event.data.get("fingerprint") or ["{{ default }}"]`).
     if let Some(fingerprint) = event_data.get("fingerprint").and_then(|f| f.as_array()) {
-        return fingerprint
+        let parts: Vec<String> = fingerprint
             .iter()
             .filter_map(|part| {
                 let coerced = coerce_fingerprint_element(part)?;
@@ -25,8 +28,10 @@ pub fn calculate_grouping_key(event_data: &Value) -> String {
                     Some(coerced)
                 }
             })
-            .collect::<Vec<_>>()
-            .join(GROUPING_SEPARATOR);
+            .collect();
+        if !parts.is_empty() {
+            return parts.join(GROUPING_SEPARATOR);
+        }
     }
 
     // Default grouping

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -397,6 +397,81 @@ async fn test_digest_handles_custom_fingerprint() {
 }
 
 #[actix_web::test]
+async fn test_digest_empty_fingerprint_does_not_collapse_issues() {
+    // Issue #290: sentry-ruby always sends `"fingerprint": []`. Distinct
+    // exceptions must still land in distinct issues with a non-empty key.
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Empty Fingerprint Project").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    for exc_type in [
+        "Rack::Multipart::BoundaryTooLongError",
+        "Rack::Multipart::EmptyContentError",
+    ] {
+        let event_id = Uuid::new_v4().to_string().replace("-", "");
+        let event_json = json!({
+            "event_id": &event_id,
+            "timestamp": Utc::now().timestamp() as f64,
+            "platform": "ruby",
+            "level": "error",
+            "transaction": "/upload",
+            "fingerprint": [],
+            "exception": {
+                "values": [{ "type": exc_type, "value": "boom" }]
+            }
+        });
+        let event_bytes = serde_json::to_vec(&event_json).unwrap();
+
+        store_event(ingest_dir, &event_id, &event_bytes)
+            .await
+            .expect("Failed to store event");
+
+        let metadata = EventMetadata {
+            event_id: event_id.clone(),
+            project_id: project.id,
+            ingested_at: Utc::now(),
+            remote_addr: None,
+        };
+
+        process_error_event(
+            &db.pool,
+            &metadata,
+            ingest_dir,
+            &rate_limit_config,
+            crate::common::null_sourcemap_provider(),
+        )
+        .await
+        .expect("Failed to process event");
+    }
+
+    let (issues, _) = IssueService::list_paginated(
+        &db.pool,
+        project.id,
+        rustrak::pagination::IssueSort::DigestOrder,
+        rustrak::pagination::SortOrder::Desc,
+        true,
+        None,
+        100,
+    )
+    .await
+    .expect("Failed to list issues");
+
+    assert_eq!(issues.len(), 2);
+
+    let keys: Vec<String> = sqlx::query_scalar("SELECT grouping_key FROM groupings")
+        .fetch_all(&db.pool)
+        .await
+        .expect("Failed to read groupings");
+    assert_eq!(keys.len(), 2);
+    assert!(
+        keys.iter().all(|k| !k.is_empty()),
+        "grouping keys: {keys:?}"
+    );
+}
+
+#[actix_web::test]
 async fn test_digest_handles_default_fingerprint_placeholder() {
     let db = TestDb::new().await;
     let project = create_test_project(&db.pool, "Default Fingerprint Project").await;

--- a/apps/server/tests/unit/grouping_test.rs
+++ b/apps/server/tests/unit/grouping_test.rs
@@ -315,9 +315,44 @@ fn test_empty_fingerprint_array() {
     });
 
     let key = calculate_grouping_key(&event);
-    // Empty fingerprint = falls back to default
-    // Actually empty array is still truthy, so key will be empty
-    assert_eq!(key, "");
+    // Empty fingerprint = falls back to default. sentry-ruby always sends
+    // `"fingerprint": []` and Sentry treats it as "no custom fingerprint"
+    // (sentry/grouping/api.py: `event.data.get("fingerprint") or ["{{ default }}"]`).
+    assert_eq!(key, "Error: test ⋄ /api");
+}
+
+#[test]
+fn test_empty_fingerprint_does_not_collapse_distinct_errors() {
+    // Issue #290: two different exceptions with `fingerprint: []` must not
+    // land in the same issue.
+    let event1 = json!({
+        "exception": { "values": [{ "type": "BoundaryTooLongError", "value": "a" }] },
+        "transaction": "/upload",
+        "fingerprint": []
+    });
+    let event2 = json!({
+        "exception": { "values": [{ "type": "EmptyContentError", "value": "b" }] },
+        "transaction": "/upload",
+        "fingerprint": []
+    });
+
+    assert_ne!(
+        calculate_grouping_key(&event1),
+        calculate_grouping_key(&event2)
+    );
+}
+
+#[test]
+fn test_fingerprint_of_only_dropped_elements_falls_back_to_default() {
+    // Relay turns `[null]` into an empty fingerprint, which serializes as
+    // absent; Sentry then uses default grouping.
+    let event = json!({
+        "exception": { "values": [{ "type": "Error", "value": "test" }] },
+        "transaction": "/api",
+        "fingerprint": [null, [1, 2], {"k": "v"}]
+    });
+
+    assert_eq!(calculate_grouping_key(&event), "Error: test ⋄ /api");
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #290

## Problem

sentry-ruby initialises `@fingerprint = []` and always serialises it, so every Ruby event arrives with `"fingerprint": []`. Rustrak treated any fingerprint array as an explicit fingerprint, computed the grouping key `""`, and every later event in the project matched that grouping regardless of exception type or transaction.

Sentry treats an empty fingerprint as "no custom fingerprint": Relay parses `[]` (or `[null]` after dropping invalid parts) into an empty fingerprint that serialises as absent, and the monolith falls back with `event.data.get("fingerprint") or ["{{ default }}"]` (`sentry/grouping/api.py`).

## Fix

`calculate_grouping_key` now falls through to default grouping when the fingerprint is empty after coercion. Non-empty fingerprints, `{{ default }}` placeholders and `[""]` behave as before.

## Tests

- Unit: `test_empty_fingerprint_array` (previously asserted the buggy `""`), `test_empty_fingerprint_does_not_collapse_distinct_errors`, `test_fingerprint_of_only_dropped_elements_falls_back_to_default`.
- Integration: `test_digest_empty_fingerprint_does_not_collapse_issues` reproduces the report (two distinct exceptions with `fingerprint: []`); it produced 1 issue before the fix and 2 after.
- Verified against the running binary via `POST /api/{project}/envelope/`: distinct exceptions with `[]` land in distinct issues, `["custom-key"]` still groups together, `[null]` falls back to default, no empty `grouping_key` rows.

## Note for existing deployments

Issues already created with `grouping_key = ''` are kept; new events simply stop matching them after upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue grouping when custom fingerprints are empty or contain unsupported values.
  * Events now fall back to default grouping in these cases, preventing missing or invalid grouping keys.
  * Distinct exceptions with empty fingerprints are grouped into separate issues.

* **Tests**
  * Added coverage for Ruby events and fingerprint edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->