### PR TITLE
refactor: enforce a cognitive complexity limit and clear the 28 violations

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,12 @@ reviews:
     labels:
       - "!skip-review"
 
+    # CodeRabbit reviews only PRs onto the default branch unless told otherwise,
+    # so a PR onto a feature branch got no review at all. `.*` is every base;
+    # the label and title guards below still decide what gets skipped.
+    base_branches:
+      - ".*"
+
     # Second guard for that same PR. The label can only be applied after the PR
     # exists, so a review can start before it lands; the title is set at
     # creation time and cannot race. release.yml pins the title literally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
+  # Every pull request, whatever it targets. Deliberately unfiltered: a `branches`
+  # filter here matches the PR's *base*, so gating on `main` meant a stacked PR
+  # or one onto a long-lived feature branch merged with no checks at all. The
+  # work is the same work regardless of where it lands.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,9 @@ on:
       - "apps/webview-ui/**"
       - "packages/**"
       - ".github/workflows/codeql.yml"
+  # No `branches` filter: it matches the PR's base, and a PR onto a feature
+  # branch carries the same code as one onto main. `paths` still applies.
   pull_request:
-    branches: ["main"]
     paths:
       - "apps/server/**"
       - "apps/webview-ui/**"

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -6,8 +6,9 @@ on:
     paths:
       - "apps/server/**"
       - "deny.toml"
+  # No `branches` filter: it matches the PR's base, and a PR onto a feature
+  # branch carries the same dependencies as one onto main.
   pull_request:
-    branches: ["main"]
     paths:
       - "apps/server/**"
       - "deny.toml"

--- a/apps/webview-ui/src/__tests__/architecture/message-keys.test.ts
+++ b/apps/webview-ui/src/__tests__/architecture/message-keys.test.ts
@@ -116,6 +116,32 @@ const OTHER_LOCALES: readonly (readonly [string, Messages])[] = [
   ['ro', ro],
 ];
 
+/** A file whose translator calls this rule can judge. */
+function isJudgeable(path: string): boolean {
+  if (isTestFile(path)) return false;
+  // The dictionaries themselves hold the keys; they do not call them.
+  return !path.split('\\').join('/').includes('/messages/');
+}
+
+/**
+ * Every fully-qualified message key this file asks for.
+ *
+ * A generator so the two nested walks -- translators, then the calls on each
+ * -- stay one flat statement at the call site rather than a loop inside a
+ * loop inside a predicate.
+ */
+function* translatedKeys(content: string): Generator<string> {
+  for (const binding of content.matchAll(TRANSLATOR_BINDING)) {
+    const [, name, quoted, fromObject] = binding;
+    const namespace = quoted ?? fromObject ?? '';
+
+    for (const call of content.matchAll(callsOf(name))) {
+      const key = call[1];
+      yield namespace ? `${namespace}.${key}` : key;
+    }
+  }
+}
+
 describe('message dictionaries stay resolvable', () => {
   it('every locale exposes exactly the same keys as en', () => {
     const enKeys = leafKeys(en as Messages);
@@ -153,24 +179,14 @@ describe('message dictionaries stay resolvable', () => {
     const rule = projectFiles()
       .inFolder('src/**')
       .shouldNot()
-      .adhereTo((file) => {
-        if (isTestFile(file.path)) return false;
-        if (file.path.split('\\').join('/').includes('/messages/')) {
-          return false;
-        }
-
-        for (const binding of file.content.matchAll(TRANSLATOR_BINDING)) {
-          const [, name, quoted, fromObject] = binding;
-          const namespace = quoted ?? fromObject ?? '';
-
-          for (const call of file.content.matchAll(callsOf(name))) {
-            const key = call[1];
-            const full = namespace ? `${namespace}.${key}` : key;
-            if (!hasKey(en as Messages, full)) return true;
-          }
-        }
-        return false;
-      }, 'calls a translator with a message key that does not exist in en.json');
+      .adhereTo(
+        (file) =>
+          isJudgeable(file.path) &&
+          [...translatedKeys(file.content)].some(
+            (key) => !hasKey(en as Messages, key),
+          ),
+        'calls a translator with a message key that does not exist in en.json',
+      );
 
     await expect(rule).toPassAsync();
   });

--- a/apps/webview-ui/src/app/(main)/projects/[id]/agents/[traceId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/agents/[traceId]/page.tsx
@@ -11,13 +11,16 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getFormatter, getTranslations } from 'next-intl/server';
 import { getSpan, listSpans } from '@/features/agent-trace/api/queries';
-import { defaultSelectedSpanId } from '@/features/agent-trace/model/filters';
+import {
+  resolveSelectedSpan,
+  summarizeTrace,
+} from '@/features/agent-trace/model/trace-summary';
 import { AgentTraceWaterfall } from '@/features/agent-trace/ui/components/agent-trace-waterfall';
-import { AiSpanDetail } from '@/features/agent-trace/ui/components/ai-span-detail';
+import { SpanDetailPane } from '@/features/agent-trace/ui/components/span-detail-pane';
+import { TraceSummaryBadges } from '@/features/agent-trace/ui/components/trace-summary-badges';
 import { getProject } from '@/features/project/api/queries';
 import { loadAll } from '@/shared/lib/results';
 import { LoadFailure } from '@/shared/ui/components/load-failure';
-import { Badge } from '@/shared/ui/components/shadcn/badge';
 
 interface AgentTraceDetailPageProps {
   params: Promise<{ id: string; traceId: string }>;
@@ -72,7 +75,7 @@ async function collectAllSpans(
   return Ok(spans);
 }
 
-function formatDuration(ms: number | null): string {
+function _formatDuration(ms: number | null): string {
   if (ms == null) return '—';
   if (ms < 1000) return `${Math.round(ms)}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
@@ -83,7 +86,7 @@ export default async function AgentTraceDetailPage({
   searchParams,
 }: AgentTraceDetailPageProps) {
   const t = await getTranslations('projectPages');
-  const format = await getFormatter();
+  const _format = await getFormatter();
   const { id, traceId } = await params;
   const { span: requestedSpanId } = await searchParams;
   const projectId = parseInt(id, 10);
@@ -112,62 +115,12 @@ export default async function AgentTraceDetailPage({
     notFound();
   }
 
-  const agentName = spans.find((s) => s.gen_ai_agent_name)?.gen_ai_agent_name;
-  const starts = spans
-    .map((s) => (s.start_timestamp ? Date.parse(s.start_timestamp) : null))
-    .filter((v): v is number => v != null);
-  const ends = spans
-    .map((s) => (s.timestamp ? Date.parse(s.timestamp) : null))
-    .filter((v): v is number => v != null);
-  const duration =
-    starts.length > 0 && ends.length > 0
-      ? Math.max(...ends) - Math.min(...starts)
-      : null;
-  // Agent spans aggregate their children's usage, so including them here
-  // would count the same tokens twice — the Traces query excludes them too.
-  const totalTokens = spans
-    .filter((s) => s.gen_ai_operation_type !== 'agent')
-    .reduce((sum, s) => sum + (s.gen_ai_usage_total_tokens ?? 0), 0);
-  const toolCallCount = spans.filter(
-    (s) => s.gen_ai_operation_type === 'tool',
-  ).length;
-  const llmCallCount = spans.filter(
-    (s) => s.gen_ai_operation_type === 'ai_client',
-  ).length;
-  const errorCount = spans.filter(
-    (s) => s.status != null && s.status !== 'ok',
-  ).length;
-  // Response model where the SDK reported one, request model otherwise: a
-  // failed call has no response model but still names what it tried to call.
-  const models = [
-    ...new Set(
-      spans.flatMap((s) => {
-        const model = s.gen_ai_response_model ?? s.gen_ai_request_model;
-        return model ? [model] : [];
-      }),
-    ),
-  ];
-  const startedAt = starts.length > 0 ? Math.min(...starts) : null;
+  const summary = summarizeTrace(spans);
 
-  // Opening a trace with an empty details panel wastes the whole right half
-  // of the page on "select a span". Sentry defaults to the first generation
-  // span for the same reason, and the URL stays clean until the reader picks
-  // one themselves.
-  //
-  // A requested id is honoured only if it belongs to this trace. `getSpan` is
-  // scoped to the project, not the trace, so without this check a span from
-  // another trace would render beside this one's waterfall — the URL and the
-  // panel describing different things. It also means the only ids that ever
-  // reach the request are ones already loaded from the server.
-  const requestedSpanIsInTrace =
-    requestedSpanId != null && spans.some((s) => s.id === requestedSpanId);
-  const selectedSpanId = requestedSpanIsInTrace
-    ? requestedSpanId
-    : requestedSpanId == null
-      ? defaultSelectedSpanId(spans)
-      : undefined;
-  const requestedSpanMissing =
-    requestedSpanId != null && !requestedSpanIsInTrace;
+  const { selectedSpanId, requestedMissing } = resolveSelectedSpan(
+    spans,
+    requestedSpanId,
+  );
 
   // Only the selected span: attributes are the one part of a span that is
   // never trimmed server-side, so they are pulled one at a time.
@@ -185,41 +138,10 @@ export default async function AgentTraceDetailPage({
           {t('trace.backLink')}
         </Link>
         <h1 className="font-mono text-lg font-semibold break-all">
-          {agentName || t('trace.unnamed')}
+          {summary.agentName || t('trace.unnamed')}
         </h1>
-        <div className="mt-2 flex items-center gap-2 flex-wrap text-sm">
-          <span className="font-mono font-semibold">
-            {formatDuration(duration)}
-          </span>
-          <Badge variant="secondary">
-            {t('trace.tokens', { count: format.number(totalTokens) })}
-          </Badge>
-          {llmCallCount > 0 && (
-            <Badge variant="outline">
-              {t('trace.llmCalls', { count: llmCallCount })}
-            </Badge>
-          )}
-          {toolCallCount > 0 && (
-            <Badge variant="outline">
-              {t('trace.toolCalls', { count: toolCallCount })}
-            </Badge>
-          )}
-          {errorCount > 0 && (
-            <Badge variant="destructive">
-              {t('trace.errors', { count: errorCount })}
-            </Badge>
-          )}
-          {models.map((model) => (
-            <Badge key={model} variant="outline" className="font-mono">
-              {model}
-            </Badge>
-          ))}
-          {startedAt != null && (
-            <span className="text-xs text-muted-foreground">
-              {format.dateTime(new Date(startedAt), 'precise')}
-            </span>
-          )}
-        </div>
+        <TraceSummaryBadges summary={summary} />
+
         <p className="mt-1 text-xs text-muted-foreground font-mono truncate">
           {traceId}
         </p>
@@ -258,29 +180,10 @@ export default async function AgentTraceDetailPage({
             </h2>
           </div>
           <div className="p-4 lg:overflow-auto">
-            {requestedSpanMissing ||
-            (selected?.success === false &&
-              selected.error.kind === 'not_found') ? (
-              // A stale link, not an outage — say so in place rather than
-              // replacing the whole trace view with a failure surface.
-              <p className="text-sm text-muted-foreground">
-                {t('trace.spanUnavailable')}
-              </p>
-            ) : selected == null ? (
-              <p className="text-sm text-muted-foreground">
-                {t('trace.selectSpan')}
-              </p>
-            ) : selected.success ? (
-              <AiSpanDetail span={selected.data} />
-            ) : (
-              // Anything else is a real failure. Reporting a timeout or a 500
-              // as "that span is no longer available" would send the reader
-              // looking for a deleted span that is still there.
-              <LoadFailure
-                error={selected.error}
-                title={t('trace.loadFailed')}
-              />
-            )}
+            <SpanDetailPane
+              selected={selected}
+              requestedMissing={requestedMissing}
+            />
           </div>
         </section>
       </div>

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/_components/event-identity-bar.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/_components/event-identity-bar.tsx
@@ -1,0 +1,86 @@
+import type { EventDetail } from '@rustrak/client';
+import { getFormatter, getTranslations } from 'next-intl/server';
+import type { EventNavigation } from '@/features/event/api/queries';
+import type { EventJumpTarget } from '@/features/event/lib/event-jumps';
+import { EventNavigationBar } from '@/features/event/ui/components/event-navigation';
+
+interface EventIdentityBarProps {
+  projectId: number;
+  issueId: string;
+  event: EventDetail;
+  navigation: EventNavigation;
+  jumps: { id: EventJumpTarget; label: string }[];
+}
+
+/**
+ * Which event this is, and where else to go in it.
+ *
+ * Sticks to the top on scroll from `sm` up: a stack trace is long, and losing
+ * track of which of an issue's events is on screen while reading one is the
+ * mistake this band exists to prevent.
+ */
+export async function EventIdentityBar({
+  projectId,
+  issueId,
+  event,
+  navigation,
+  jumps,
+}: EventIdentityBarProps) {
+  const t = await getTranslations('projectPages');
+  const format = await getFormatter();
+
+  return (
+    <div className="sm:sticky sm:top-0 sm:z-20 -mx-4 md:-mx-8 border-b bg-background px-4 md:px-8 pt-1 pb-3 space-y-3 sm:space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm">
+          <span className="font-semibold">{t('event.events')}</span>{' '}
+          <span className="text-muted-foreground">
+            {t('event.inThisIssue')}
+          </span>
+        </p>
+        <EventNavigationBar
+          projectId={projectId}
+          issueId={issueId}
+          navigation={navigation}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+        <div className="flex items-center gap-2 flex-wrap min-w-0">
+          <span>
+            {t('event.idLabel')}{' '}
+            <span className="font-mono text-foreground">
+              {event.event_id.slice(0, 8)}
+            </span>
+          </span>
+          <span className="text-muted-foreground/40">·</span>
+          <span>{format.relativeTime(new Date(event.timestamp))}</span>
+          {event.platform && (
+            <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground/80">
+              {event.platform}
+            </span>
+          )}
+          {event.environment && (
+            <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground/80">
+              {event.environment}
+            </span>
+          )}
+        </div>
+        {jumps.length > 0 && (
+          <div className="flex items-center gap-3 flex-wrap shrink-0">
+            <span>{t('event.jumpTo')}</span>
+            {jumps.map((j) => (
+              <a
+                key={j.id}
+                href={`#${j.id}`}
+                className="hover:text-foreground transition-colors"
+              >
+                {j.label}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/_components/event-rail.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/_components/event-rail.tsx
@@ -1,0 +1,63 @@
+import type { ActivityEntry, Issue } from '@rustrak/client';
+import { getFormatter, getTranslations } from 'next-intl/server';
+import { IssueActivity } from '@/features/issue/ui/components/issue-activity';
+
+interface EventRailProps {
+  projectId: number;
+  issueId: string;
+  issue: Issue;
+  activity: ActivityEntry[];
+}
+
+/**
+ * The side rail: when the issue was last and first seen, and what has
+ * happened to it since.
+ *
+ * About the **issue**, not the event being read. That is why it sits beside
+ * the page rather than in it: the event is one sample, and these are the facts
+ * that put it in context.
+ */
+export async function EventRail({
+  projectId,
+  issueId,
+  issue,
+  activity,
+}: EventRailProps) {
+  const t = await getTranslations('projectPages');
+  const format = await getFormatter();
+
+  return (
+    <>
+      <div className="p-4 space-y-1.5 border-b">
+        <div className="flex items-baseline justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">{t('event.lastSeen')}</span>
+          <span title={format.dateTime(new Date(issue.last_seen), 'precise')}>
+            {format.relativeTime(new Date(issue.last_seen))}
+          </span>
+        </div>
+        <div className="flex items-baseline justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">{t('event.firstSeen')}</span>
+          <span title={format.dateTime(new Date(issue.first_seen), 'precise')}>
+            {format.relativeTime(new Date(issue.first_seen))}
+          </span>
+        </div>
+        {issue.last_release && (
+          <p className="text-xs text-muted-foreground truncate pt-1">
+            {t.rich('event.inRelease', {
+              release: issue.last_release,
+              rel: (chunks) => <span className="font-mono">{chunks}</span>,
+            })}
+          </p>
+        )}
+      </div>
+
+      <div className="p-4">
+        <IssueActivity
+          projectId={projectId}
+          issueId={issueId}
+          activity={activity}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/issues/[issueId]/events/[eventId]/page.tsx
@@ -1,27 +1,31 @@
 import type { Metadata } from 'next';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 import {
   getEventDetail,
   getEventNavigation,
 } from '@/features/event/api/queries';
 import {
+  type EventJumpTarget,
+  eventJumpTargets,
+} from '@/features/event/lib/event-jumps';
+import {
   readEventPayload,
   splitIssueTitle,
 } from '@/features/event/lib/event-payload';
-import { EventNavigationBar } from '@/features/event/ui/components/event-navigation';
 import {
   getIssue,
   getIssueActivity,
   getIssueAggregates,
   getIssueStats,
 } from '@/features/issue/api/queries';
-import { IssueActivity } from '@/features/issue/ui/components/issue-activity';
 import { TagDistribution } from '@/features/issue/ui/components/tag-distribution';
 import { getProject } from '@/features/project/api/queries';
 import { CollapsibleRail } from '@/shared/ui/components/collapsible-rail';
 import { EventChart } from '@/shared/ui/components/event-chart';
 import { LoadFailure } from '@/shared/ui/components/load-failure';
 import { EventHeader } from './_components/event-header';
+import { EventIdentityBar } from './_components/event-identity-bar';
+import { EventRail } from './_components/event-rail';
 import { EventSections } from './_components/event-sections';
 
 interface EventPageProps {
@@ -65,7 +69,6 @@ const compact = (n: number) =>
   }).format(n);
 
 export default async function EventPage({ params }: EventPageProps) {
-  const format = await getFormatter();
   const t = await getTranslations('projectPages');
   const { id, issueId, eventId } = await params;
   const projectId = parseInt(id, 10);
@@ -139,54 +142,28 @@ export default async function EventPage({ params }: EventPageProps) {
   const userCount = aggregates?.user_count ?? 0;
   const total30d = stats30d?.data.reduce((s, [, c]) => s + c, 0) ?? 0;
 
-  // "Jump to" anchors — only for sections that exist.
-  const jumps = [
-    { id: 'highlights', label: t('event.sectionHighlights') },
-    has.stackTrace && { id: 'stacktrace', label: t('event.sectionStackTrace') },
-    has.breadcrumbs && {
-      id: 'breadcrumbs',
-      label: t('event.sectionBreadcrumbs'),
-    },
-    has.tags && { id: 'tags', label: t('event.sectionTags') },
-    (has.contexts || has.modules || has.user) && {
-      id: 'context',
-      label: t('event.sectionContext'),
-    },
-  ].filter(Boolean) as { id: string; label: string }[];
+  // One entry per section the event actually has. Labelled here rather than
+  // in `eventJumpTargets` so every message key stays a literal the
+  // message-keys architecture rule can check.
+  const SECTION_LABELS: Record<EventJumpTarget, string> = {
+    highlights: t('event.sectionHighlights'),
+    stacktrace: t('event.sectionStackTrace'),
+    breadcrumbs: t('event.sectionBreadcrumbs'),
+    tags: t('event.sectionTags'),
+    context: t('event.sectionContext'),
+  };
+  const jumps = eventJumpTargets(has).map((id) => ({
+    id,
+    label: SECTION_LABELS[id],
+  }));
 
   const rail = (
-    <>
-      <div className="p-4 space-y-1.5 border-b">
-        <div className="flex items-baseline justify-between gap-2 text-sm">
-          <span className="text-muted-foreground">{t('event.lastSeen')}</span>
-          <span title={format.dateTime(new Date(issue.last_seen), 'precise')}>
-            {format.relativeTime(new Date(issue.last_seen))}
-          </span>
-        </div>
-        <div className="flex items-baseline justify-between gap-2 text-sm">
-          <span className="text-muted-foreground">{t('event.firstSeen')}</span>
-          <span title={format.dateTime(new Date(issue.first_seen), 'precise')}>
-            {format.relativeTime(new Date(issue.first_seen))}
-          </span>
-        </div>
-        {issue.last_release && (
-          <p className="text-xs text-muted-foreground truncate pt-1">
-            {t.rich('event.inRelease', {
-              release: issue.last_release,
-              rel: (chunks) => <span className="font-mono">{chunks}</span>,
-            })}
-          </p>
-        )}
-      </div>
-
-      <div className="p-4">
-        <IssueActivity
-          projectId={projectId}
-          issueId={issueId}
-          activity={activity}
-        />
-      </div>
-    </>
+    <EventRail
+      projectId={projectId}
+      issueId={issueId}
+      issue={issue}
+      activity={activity}
+    />
   );
 
   return (
@@ -250,59 +227,13 @@ export default async function EventPage({ params }: EventPageProps) {
               </div>
             </div>
 
-            {/* Event nav + identity + jump-to (sticks to the top on scroll, sm+) */}
-            <div className="sm:sticky sm:top-0 sm:z-20 -mx-4 md:-mx-8 border-b bg-background px-4 md:px-8 pt-1 pb-3 space-y-3 sm:space-y-2">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-sm">
-                  <span className="font-semibold">{t('event.events')}</span>{' '}
-                  <span className="text-muted-foreground">
-                    {t('event.inThisIssue')}
-                  </span>
-                </p>
-                <EventNavigationBar
-                  projectId={projectId}
-                  issueId={issueId}
-                  navigation={navigation}
-                />
-              </div>
-
-              <div className="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-2">
-                <div className="flex items-center gap-2 flex-wrap min-w-0">
-                  <span>
-                    {t('event.idLabel')}{' '}
-                    <span className="font-mono text-foreground">
-                      {event.event_id.slice(0, 8)}
-                    </span>
-                  </span>
-                  <span className="text-muted-foreground/40">·</span>
-                  <span>{format.relativeTime(new Date(event.timestamp))}</span>
-                  {event.platform && (
-                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground/80">
-                      {event.platform}
-                    </span>
-                  )}
-                  {event.environment && (
-                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground/80">
-                      {event.environment}
-                    </span>
-                  )}
-                </div>
-                {jumps.length > 0 && (
-                  <div className="flex items-center gap-3 flex-wrap shrink-0">
-                    <span>{t('event.jumpTo')}</span>
-                    {jumps.map((j) => (
-                      <a
-                        key={j.id}
-                        href={`#${j.id}`}
-                        className="hover:text-foreground transition-colors"
-                      >
-                        {j.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
+            <EventIdentityBar
+              projectId={projectId}
+              issueId={issueId}
+              event={event}
+              navigation={navigation}
+              jumps={jumps}
+            />
 
             <EventSections
               event={event}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/_components/transaction-badges.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/_components/transaction-badges.tsx
@@ -1,0 +1,56 @@
+import type { TransactionDetail } from '@rustrak/client';
+import { getFormatter } from 'next-intl/server';
+import { Badge } from '@/shared/ui/components/shadcn/badge';
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+interface TransactionBadgesProps {
+  txn: TransactionDetail;
+  /** From the trace context, which is where the SDK puts them. */
+  op: string | undefined;
+  status: string | undefined;
+}
+
+/**
+ * What this transaction was, in one line.
+ *
+ * Everything except the duration and the timestamp is hidden when absent: an
+ * SDK that reports no environment should leave a gap, not an empty badge.
+ */
+export async function TransactionBadges({
+  txn,
+  op,
+  status,
+}: TransactionBadgesProps) {
+  const format = await getFormatter();
+
+  return (
+    <div className="mt-2 flex items-center gap-2 flex-wrap text-sm">
+      <span className="font-mono font-semibold">
+        {formatDuration(txn.duration_ms)}
+      </span>
+
+      {op && <Badge variant="secondary">{op}</Badge>}
+      {status && (
+        <Badge variant={status === 'ok' ? 'outline' : 'destructive'}>
+          {status}
+        </Badge>
+      )}
+      {txn.environment && <Badge variant="outline">{txn.environment}</Badge>}
+      {txn.platform && <Badge variant="outline">{txn.platform}</Badge>}
+
+      {txn.release && (
+        <span className="font-mono text-xs text-muted-foreground">
+          {txn.release}
+        </span>
+      )}
+      <span className="text-xs text-muted-foreground">
+        {format.dateTime(new Date(txn.timestamp), 'precise')}
+      </span>
+    </div>
+  );
+}

--- a/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
+++ b/apps/webview-ui/src/app/(main)/projects/[id]/performance/[txnId]/page.tsx
@@ -1,15 +1,15 @@
 import { ArrowLeft } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 import { getProject } from '@/features/project/api/queries';
 import { getTransaction } from '@/features/transaction/api/queries';
-import type { Span, TraceContext } from '@/features/transaction/model/span';
+import { readTransactionPayload } from '@/features/transaction/lib/transaction-payload';
 import { MeasurementsCard } from '@/features/transaction/ui/components/measurements-card';
 import { SpanWaterfall } from '@/features/transaction/ui/components/span-waterfall';
 import { loadAll } from '@/shared/lib/results';
 import { LoadFailure } from '@/shared/ui/components/load-failure';
-import { Badge } from '@/shared/ui/components/shadcn/badge';
+import { TransactionBadges } from './_components/transaction-badges';
 
 interface TransactionDetailPageProps {
   params: Promise<{ id: string; txnId: string }>;
@@ -26,24 +26,6 @@ export async function generateMetadata({
       ? t('transaction.meta.title', { name: txn.data.transaction_name })
       : t('transaction.meta.fallbackTitle'),
   };
-}
-
-function formatDuration(ms: number | null): string {
-  if (ms === null) return '—';
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(2)}s`;
-}
-
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return null;
-}
-
-function epochSeconds(raw: unknown, fallbackIso: string): number {
-  if (typeof raw === 'number') return raw;
-  return Date.parse(fallbackIso) / 1000;
 }
 
 /** Renders the primitive entries of an object as a key/value list. */
@@ -83,7 +65,6 @@ export default async function TransactionDetailPage({
   params,
 }: TransactionDetailPageProps) {
   const t = await getTranslations('projectPages');
-  const format = await getFormatter();
   const { id, txnId } = await params;
   const projectId = parseInt(id, 10);
 
@@ -100,24 +81,18 @@ export default async function TransactionDetailPage({
 
   const [, txn] = loaded.data;
 
-  const data = txn.data ?? {};
-  const trace = asObject(data.contexts)?.trace as
-    | Record<string, unknown>
-    | undefined;
-  const spans = Array.isArray(data.spans) ? data.spans : [];
-  const measurements = asObject(data.measurements);
-  const tags = asObject(data.tags);
-  const request = asObject(data.request);
-  const user = asObject(data.user);
-
-  const transactionStart = epochSeconds(
-    data.start_timestamp,
-    txn.start_timestamp ?? txn.timestamp,
-  );
-  const transactionEnd = epochSeconds(data.timestamp, txn.timestamp);
-
-  const op = typeof trace?.op === 'string' ? trace.op : undefined;
-  const status = typeof trace?.status === 'string' ? trace.status : undefined;
+  const {
+    trace,
+    spans,
+    measurements,
+    tags,
+    request,
+    user,
+    transactionStart,
+    transactionEnd,
+    op,
+    status,
+  } = readTransactionPayload(txn);
 
   return (
     <div className="flex flex-col h-[calc(100vh-64px)]">
@@ -133,29 +108,7 @@ export default async function TransactionDetailPage({
         <h1 className="font-mono text-lg font-semibold break-all">
           {txn.transaction_name || t('transaction.unnamed')}
         </h1>
-        <div className="mt-2 flex items-center gap-2 flex-wrap text-sm">
-          <span className="font-mono font-semibold">
-            {formatDuration(txn.duration_ms)}
-          </span>
-          {op && <Badge variant="secondary">{op}</Badge>}
-          {status && (
-            <Badge variant={status === 'ok' ? 'outline' : 'destructive'}>
-              {status}
-            </Badge>
-          )}
-          {txn.environment && (
-            <Badge variant="outline">{txn.environment}</Badge>
-          )}
-          {txn.platform && <Badge variant="outline">{txn.platform}</Badge>}
-          {txn.release && (
-            <span className="font-mono text-xs text-muted-foreground">
-              {txn.release}
-            </span>
-          )}
-          <span className="text-xs text-muted-foreground">
-            {format.dateTime(new Date(txn.timestamp), 'precise')}
-          </span>
-        </div>
+        <TransactionBadges txn={txn} op={op} status={status} />
       </div>
 
       {/* Body */}
@@ -178,8 +131,8 @@ export default async function TransactionDetailPage({
               </p>
             ) : (
               <SpanWaterfall
-                spans={spans as Span[]}
-                trace={trace as TraceContext | undefined}
+                spans={spans}
+                trace={trace}
                 transactionStart={transactionStart}
                 transactionEnd={transactionEnd}
               />

--- a/apps/webview-ui/src/features/agent-trace/model/trace-summary.test.ts
+++ b/apps/webview-ui/src/features/agent-trace/model/trace-summary.test.ts
@@ -1,0 +1,163 @@
+import type { Span } from '@rustrak/client';
+import { describe, expect, it } from 'vitest';
+import { resolveSelectedSpan, summarizeTrace } from './trace-summary';
+
+function span(over: Partial<Span> & { id: string }): Span {
+  return {
+    gen_ai_operation_type: null,
+    gen_ai_agent_name: null,
+    gen_ai_request_model: null,
+    gen_ai_response_model: null,
+    gen_ai_usage_total_tokens: null,
+    start_timestamp: null,
+    timestamp: null,
+    status: null,
+    ...over,
+  } as unknown as Span;
+}
+
+describe('summarizeTrace', () => {
+  it('spans the whole trace, earliest start to latest end', () => {
+    const summary = summarizeTrace([
+      span({
+        id: 'a',
+        start_timestamp: '2026-01-01T00:00:00.000Z',
+        timestamp: '2026-01-01T00:00:01.000Z',
+      }),
+      span({
+        id: 'b',
+        start_timestamp: '2026-01-01T00:00:00.500Z',
+        timestamp: '2026-01-01T00:00:03.000Z',
+      }),
+    ]);
+
+    expect(summary.duration).toBe(3000);
+    expect(summary.startedAt).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
+  });
+
+  it('has no duration when nothing carries a timestamp', () => {
+    const summary = summarizeTrace([span({ id: 'a' })]);
+
+    expect(summary.duration).toBeNull();
+    expect(summary.startedAt).toBeNull();
+  });
+
+  /**
+   * The one rule here that is not arithmetic. An agent span reports the total
+   * for everything under it, so counting it alongside its children bills the
+   * same tokens twice. The Traces list query excludes them for the same reason.
+   */
+  it('excludes agent spans from the token total', () => {
+    const summary = summarizeTrace([
+      span({
+        id: 'agent',
+        gen_ai_operation_type: 'agent',
+        gen_ai_usage_total_tokens: 300,
+      }),
+      span({
+        id: 'llm',
+        gen_ai_operation_type: 'ai_client',
+        gen_ai_usage_total_tokens: 200,
+      }),
+      span({
+        id: 'tool',
+        gen_ai_operation_type: 'tool',
+        gen_ai_usage_total_tokens: 100,
+      }),
+    ]);
+
+    expect(summary.totalTokens).toBe(300);
+  });
+
+  it('counts calls by operation type', () => {
+    const summary = summarizeTrace([
+      span({ id: '1', gen_ai_operation_type: 'ai_client' }),
+      span({ id: '2', gen_ai_operation_type: 'ai_client' }),
+      span({ id: '3', gen_ai_operation_type: 'tool' }),
+    ]);
+
+    expect(summary.llmCallCount).toBe(2);
+    expect(summary.toolCallCount).toBe(1);
+  });
+
+  it('counts any status that is not ok as an error, but not a missing one', () => {
+    const summary = summarizeTrace([
+      span({ id: '1', status: 'ok' }),
+      span({ id: '2', status: 'internal_error' }),
+      span({ id: '3', status: null }),
+    ]);
+
+    expect(summary.errorCount).toBe(1);
+  });
+
+  it('takes the agent name from whichever span reports one', () => {
+    const summary = summarizeTrace([
+      span({ id: '1' }),
+      span({ id: '2', gen_ai_agent_name: 'researcher' }),
+    ]);
+
+    expect(summary.agentName).toBe('researcher');
+  });
+
+  it('names the requested model when a failed call reported no response one', () => {
+    // A call that threw has no response model but still names what it tried.
+    const summary = summarizeTrace([
+      span({ id: '1', gen_ai_request_model: 'claude-opus-4' }),
+    ]);
+
+    expect(summary.models).toEqual(['claude-opus-4']);
+  });
+
+  it('prefers the response model and lists each one once', () => {
+    const summary = summarizeTrace([
+      span({
+        id: '1',
+        gen_ai_request_model: 'asked-for',
+        gen_ai_response_model: 'answered-with',
+      }),
+      span({ id: '2', gen_ai_response_model: 'answered-with' }),
+    ]);
+
+    expect(summary.models).toEqual(['answered-with']);
+  });
+});
+
+describe('resolveSelectedSpan', () => {
+  const spans = [
+    span({ id: 'a', gen_ai_operation_type: 'ai_client' }),
+    span({ id: 'b' }),
+  ];
+
+  it('honours a requested span that belongs to this trace', () => {
+    expect(resolveSelectedSpan(spans, 'b')).toEqual({
+      selectedSpanId: 'b',
+      requestedMissing: false,
+    });
+  });
+
+  /**
+   * `getSpan` is scoped to the project, not the trace, so without this a span
+   * from another trace would render beside this one's waterfall: the URL and
+   * the panel describing different things.
+   */
+  it('refuses a span from another trace and says it is missing', () => {
+    expect(resolveSelectedSpan(spans, 'elsewhere')).toEqual({
+      selectedSpanId: undefined,
+      requestedMissing: true,
+    });
+  });
+
+  it('opens the default span when none was requested', () => {
+    expect(resolveSelectedSpan(spans, undefined)).toEqual({
+      selectedSpanId: 'a',
+      requestedMissing: false,
+    });
+  });
+
+  it('selects nothing for an empty trace', () => {
+    expect(resolveSelectedSpan([], undefined)).toEqual({
+      selectedSpanId: undefined,
+      requestedMissing: false,
+    });
+  });
+});

--- a/apps/webview-ui/src/features/agent-trace/model/trace-summary.ts
+++ b/apps/webview-ui/src/features/agent-trace/model/trace-summary.ts
@@ -1,0 +1,113 @@
+import type { Span } from '@rustrak/client';
+import { defaultSelectedSpanId } from './filters';
+
+/** The header figures for one agent trace. */
+export interface TraceSummary {
+  /** The first agent name any span reports, or `undefined`. */
+  agentName: string | null | undefined;
+  /** Earliest start to latest end, in ms, or `null` if nothing is timed. */
+  duration: number | null;
+  /** Epoch ms of the earliest span, or `null`. */
+  startedAt: number | null;
+  totalTokens: number;
+  toolCallCount: number;
+  llmCallCount: number;
+  errorCount: number;
+  /** Every model the trace touched, each listed once. */
+  models: string[];
+}
+
+function epochMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Everything the trace header states, derived from the spans in one pass of
+ * the list per figure.
+ *
+ * Pure and out of the page on purpose: the double-counting rule below is a
+ * fact about the gen_ai semantics, not about this route, and it is the kind of
+ * thing that should be provable rather than commented.
+ */
+export function summarizeTrace(spans: Span[]): TraceSummary {
+  const starts = spans
+    .map((s) => epochMs(s.start_timestamp))
+    .filter((v): v is number => v != null);
+  const ends = spans
+    .map((s) => epochMs(s.timestamp))
+    .filter((v): v is number => v != null);
+
+  const timed = starts.length > 0 && ends.length > 0;
+
+  return {
+    agentName: spans.find((s) => s.gen_ai_agent_name)?.gen_ai_agent_name,
+
+    duration: timed ? Math.max(...ends) - Math.min(...starts) : null,
+    startedAt: starts.length > 0 ? Math.min(...starts) : null,
+
+    // Agent spans aggregate their children's usage, so including them here
+    // would count the same tokens twice -- the Traces query excludes them too.
+    totalTokens: spans
+      .filter((s) => s.gen_ai_operation_type !== 'agent')
+      .reduce((sum, s) => sum + (s.gen_ai_usage_total_tokens ?? 0), 0),
+
+    toolCallCount: spans.filter((s) => s.gen_ai_operation_type === 'tool')
+      .length,
+    llmCallCount: spans.filter((s) => s.gen_ai_operation_type === 'ai_client')
+      .length,
+    errorCount: spans.filter((s) => s.status != null && s.status !== 'ok')
+      .length,
+
+    // Response model where the SDK reported one, request model otherwise: a
+    // failed call has no response model but still names what it tried to call.
+    models: [
+      ...new Set(
+        spans.flatMap((s) => {
+          const model = s.gen_ai_response_model ?? s.gen_ai_request_model;
+          return model ? [model] : [];
+        }),
+      ),
+    ],
+  };
+}
+
+export interface SelectedSpan {
+  selectedSpanId: string | undefined;
+  /** The URL named a span this trace does not contain. */
+  requestedMissing: boolean;
+}
+
+/**
+ * Which span the details panel opens on.
+ *
+ * Opening a trace with an empty panel wastes the whole right half of the page
+ * on "select a span", so with nothing requested it falls to the first
+ * generation span. Sentry defaults the same way, and the URL stays clean until
+ * the reader picks one themselves.
+ *
+ * A requested id is honoured only if it belongs to this trace. `getSpan` is
+ * scoped to the project, not the trace, so without this check a span from
+ * another trace would render beside this one's waterfall -- the URL and the
+ * panel describing different things. It also means the only ids that ever
+ * reach the request are ones already loaded from the server.
+ */
+export function resolveSelectedSpan(
+  spans: Span[],
+  requestedSpanId: string | undefined,
+): SelectedSpan {
+  if (requestedSpanId == null) {
+    return {
+      selectedSpanId: defaultSelectedSpanId(spans),
+      requestedMissing: false,
+    };
+  }
+
+  const inTrace = spans.some((s) => s.id === requestedSpanId);
+
+  return {
+    selectedSpanId: inTrace ? requestedSpanId : undefined,
+    requestedMissing: !inTrace,
+  };
+}

--- a/apps/webview-ui/src/features/agent-trace/ui/components/agent-trace-waterfall.tsx
+++ b/apps/webview-ui/src/features/agent-trace/ui/components/agent-trace-waterfall.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 import { cn } from '@/shared/lib/utils';
+import { barGeometry } from '@/shared/lib/waterfall-geometry';
 
 interface AgentTraceWaterfallProps {
   spans: Span[];
@@ -232,121 +233,143 @@ export function AgentTraceWaterfall({
       )}
 
       <div className="space-y-0.5 font-mono text-xs">
-        {rows.map(
-          ({ span, depth, hasChildren, collapsed: isCol, selfMs }, i) => {
-            const dur = span.duration_ms;
-            const start = epochMs(span.start_timestamp);
-            const offsetPct =
-              start != null && total > 0
-                ? ((start - traceStart) / total) * 100
-                : 0;
-            const widthPct =
-              dur != null && total > 0 ? Math.max(0.5, (dur / total) * 100) : 0;
-            const clampedWidth = Math.min(widthPct, 100 - offsetPct);
-            const failed = span.status && span.status !== 'ok';
-            const isSelected = selectedSpanId === span.id;
-            const label =
-              span.gen_ai_agent_name ||
-              span.gen_ai_tool_name ||
-              span.gen_ai_response_model ||
-              span.description;
+        {rows.map((row, i) => (
+          // `span_id` is the key wherever the span has one. The index is the
+          // fallback for a span the SDK sent without an id, which nothing else
+          // can distinguish.
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <AgentTraceRow
+            key={row.span.span_id ?? `span-${i}`}
+            row={row}
+            projectId={projectId}
+            traceId={traceId}
+            traceStart={traceStart}
+            total={total}
+            isSelected={selectedSpanId === row.span.id}
+            onToggle={toggle}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
 
-            // Selecting toggles: clicking the open row closes the panel.
-            const href = isSelected
-              ? `/projects/${projectId}/agents/${traceId}`
-              : `/projects/${projectId}/agents/${traceId}?span=${span.id}`;
+interface AgentTraceRowProps {
+  row: FlatRow;
+  projectId: number;
+  traceId: string;
+  /** Epoch ms of the earliest span, the left edge of every bar's track. */
+  traceStart: number;
+  /** Span of the whole trace in ms, the width of that track. */
+  total: number;
+  isSelected: boolean;
+  onToggle: (id?: string | null) => void;
+}
 
-            return (
-              // `span_id` is the key wherever the span has one. The index is
-              // the fallback for a span the SDK sent without an id, which
-              // nothing else can distinguish.
-              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-              <div
-                key={span.span_id ?? `span-${i}`}
-                className={cn(
-                  'flex w-full items-center gap-1 rounded-md pr-2 hover:bg-muted/40',
-                  isSelected && 'bg-muted/50',
-                )}
-              >
-                {/* The collapse control is a sibling of the row link, not a
-                    child of it. It used to be nested inside the selectable
-                    row, which meant one interactive element inside another and
-                    a stopPropagation to keep them apart; as siblings both are
-                    plain, valid, and independently reachable by keyboard. */}
-                <div
-                  className="flex shrink-0 items-center"
-                  style={{ paddingLeft: `${Math.min(depth, 8) * 12 + 8}px` }}
-                >
-                  {hasChildren ? (
-                    <button
-                      type="button"
-                      aria-label={
-                        isCol ? t('waterfall.expand') : t('waterfall.collapse')
-                      }
-                      onClick={() => toggle(span.span_id)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      {isCol ? (
-                        <ChevronRight className="size-3" />
-                      ) : (
-                        <ChevronDown className="size-3" />
-                      )}
-                    </button>
-                  ) : (
-                    <span className="inline-block size-3" />
-                  )}
-                </div>
+/** One span on the shared clock, with its collapse control beside it. */
+function AgentTraceRow({
+  row,
+  projectId,
+  traceId,
+  traceStart,
+  total,
+  isSelected,
+  onToggle,
+}: AgentTraceRowProps) {
+  const t = useTranslations('agents');
+  const { span, depth, hasChildren, collapsed: isCol, selfMs } = row;
 
-                <Link
-                  href={href}
-                  scroll={false}
-                  aria-current={isSelected ? 'true' : undefined}
-                  className="flex min-w-0 flex-1 items-center gap-3 py-1 text-left"
-                >
-                  <div className="flex w-[38%] min-w-0 items-center gap-1">
-                    <span
-                      className={cn(
-                        'shrink-0 rounded px-1 py-px text-[10px] font-medium text-white',
-                        opColor(span),
-                      )}
-                    >
-                      {span.gen_ai_operation_type ||
-                        span.op ||
-                        t('waterfall.spanFallback')}
-                    </span>
-                    <span className="truncate text-muted-foreground">
-                      {label || '—'}
-                    </span>
-                    {failed && (
-                      <span className="shrink-0 rounded bg-destructive/15 px-1 text-[10px] text-destructive">
-                        {span.status}
-                      </span>
-                    )}
-                  </div>
-                  <div className="relative h-4 flex-1">
-                    <div
-                      className={cn(
-                        'absolute inset-y-0 rounded-sm',
-                        opColor(span),
-                      )}
-                      style={{
-                        left: `${offsetPct}%`,
-                        width: `${clampedWidth}%`,
-                      }}
-                    />
-                  </div>
-                  <span
-                    className="w-16 text-right tabular-nums text-muted-foreground"
-                    title={selfMs != null ? formatDuration(selfMs) : undefined}
-                  >
-                    {formatDuration(dur)}
-                  </span>
-                </Link>
-              </div>
-            );
-          },
+  const dur = span.duration_ms;
+  const { offsetPct, widthPct } = barGeometry(
+    epochMs(span.start_timestamp),
+    dur,
+    traceStart,
+    total,
+  );
+
+  const failed = span.status && span.status !== 'ok';
+  const label =
+    span.gen_ai_agent_name ||
+    span.gen_ai_tool_name ||
+    span.gen_ai_response_model ||
+    span.description;
+
+  // Selecting toggles: clicking the open row closes the panel.
+  const href = isSelected
+    ? `/projects/${projectId}/agents/${traceId}`
+    : `/projects/${projectId}/agents/${traceId}?span=${span.id}`;
+
+  return (
+    <div
+      className={cn(
+        'flex w-full items-center gap-1 rounded-md pr-2 hover:bg-muted/40',
+        isSelected && 'bg-muted/50',
+      )}
+    >
+      {/* The collapse control is a sibling of the row link, not a child of it.
+          It used to be nested inside the selectable row, which meant one
+          interactive element inside another and a stopPropagation to keep them
+          apart; as siblings both are plain, valid, and independently reachable
+          by keyboard. */}
+      <div
+        className="flex shrink-0 items-center"
+        style={{ paddingLeft: `${Math.min(depth, 8) * 12 + 8}px` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            aria-label={isCol ? t('waterfall.expand') : t('waterfall.collapse')}
+            onClick={() => onToggle(span.span_id)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            {isCol ? (
+              <ChevronRight className="size-3" />
+            ) : (
+              <ChevronDown className="size-3" />
+            )}
+          </button>
+        ) : (
+          <span className="inline-block size-3" />
         )}
       </div>
+
+      <Link
+        href={href}
+        scroll={false}
+        aria-current={isSelected ? 'true' : undefined}
+        className="flex min-w-0 flex-1 items-center gap-3 py-1 text-left"
+      >
+        <div className="flex w-[38%] min-w-0 items-center gap-1">
+          <span
+            className={cn(
+              'shrink-0 rounded px-1 py-px text-[10px] font-medium text-white',
+              opColor(span),
+            )}
+          >
+            {span.gen_ai_operation_type ||
+              span.op ||
+              t('waterfall.spanFallback')}
+          </span>
+          <span className="truncate text-muted-foreground">{label || '—'}</span>
+          {failed && (
+            <span className="shrink-0 rounded bg-destructive/15 px-1 text-[10px] text-destructive">
+              {span.status}
+            </span>
+          )}
+        </div>
+        <div className="relative h-4 flex-1">
+          <div
+            className={cn('absolute inset-y-0 rounded-sm', opColor(span))}
+            style={{ left: `${offsetPct}%`, width: `${widthPct}%` }}
+          />
+        </div>
+        <span
+          className="w-16 text-right tabular-nums text-muted-foreground"
+          title={selfMs != null ? formatDuration(selfMs) : undefined}
+        >
+          {formatDuration(dur)}
+        </span>
+      </Link>
     </div>
   );
 }

--- a/apps/webview-ui/src/features/agent-trace/ui/components/ai-span-detail.tsx
+++ b/apps/webview-ui/src/features/agent-trace/ui/components/ai-span-detail.tsx
@@ -75,39 +75,26 @@ export async function AiSpanDetail({ span }: AiSpanDetailProps) {
   const model = span.gen_ai_response_model ?? span.gen_ai_request_model;
   const failed = span.status != null && span.status !== 'ok';
 
-  const highlights: { key: string; label: string; value: string }[] = [];
-  if (span.gen_ai_agent_name) {
-    highlights.push({
-      key: 'agent',
-      label: t('agentName'),
-      value: span.gen_ai_agent_name,
-    });
-  }
-  if (model) {
-    highlights.push({ key: 'model', label: t('model'), value: model });
-  }
-  if (span.gen_ai_tool_name) {
-    highlights.push({
-      key: 'tool',
-      label: t('toolName'),
-      value: span.gen_ai_tool_name,
-    });
-  }
-  const reasoningEffort = attributes['gen_ai.request.reasoning_effort'];
-  if (typeof reasoningEffort === 'string' && reasoningEffort !== '') {
-    highlights.push({
+  // Declarative rather than five conditional pushes: the order of these rows
+  // is a design decision, and in a list it is visible as one.
+  const highlights = [
+    { key: 'agent', label: t('agentName'), value: span.gen_ai_agent_name },
+    { key: 'model', label: t('model'), value: model },
+    { key: 'tool', label: t('toolName'), value: span.gen_ai_tool_name },
+    {
       key: 'reasoningEffort',
       label: t('reasoningEffort'),
-      value: reasoningEffort,
-    });
-  }
-  if (span.gen_ai_conversation_id) {
-    highlights.push({
+      value: attributes['gen_ai.request.reasoning_effort'],
+    },
+    {
       key: 'conversation',
       label: t('conversationId'),
       value: span.gen_ai_conversation_id,
-    });
-  }
+    },
+  ].flatMap((row) => {
+    const value = asText(row.value);
+    return value ? [{ ...row, value }] : [];
+  });
 
   return (
     <div className="space-y-4">
@@ -153,28 +140,7 @@ export async function AiSpanDetail({ span }: AiSpanDetailProps) {
               {t('tokenMismatch')}
             </p>
           )}
-          <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1 text-xs">
-            <dt className="text-muted-foreground">{t('inputTokens')}</dt>
-            <dd className="font-mono tabular-nums">
-              {format.number(tokens.netNewInput)}
-            </dd>
-            {tokens.cached > 0 && (
-              <>
-                <dt className="text-muted-foreground">{t('cachedTokens')}</dt>
-                <dd className="font-mono tabular-nums">
-                  {format.number(tokens.cached)}
-                </dd>
-              </>
-            )}
-            <dt className="text-muted-foreground">{t('outputTokens')}</dt>
-            <dd className="font-mono tabular-nums">
-              {format.number(tokens.output)}
-            </dd>
-            <dt className="text-muted-foreground">{t('totalTokens')}</dt>
-            <dd className="font-mono font-semibold tabular-nums">
-              {format.number(tokens.total)}
-            </dd>
-          </dl>
+          <TokenBreakdownList tokens={tokens} />
         </Section>
       )}
 
@@ -204,44 +170,107 @@ export async function AiSpanDetail({ span }: AiSpanDetailProps) {
         </Section>
       )}
 
-      {output && (
-        <Section title={t('output')}>
-          {output.text && <Payload value={output.text} />}
-          {output.object && (
-            <div className="space-y-1">
-              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                {t('responseObject')}
-              </p>
-              <Payload value={output.object} />
-            </div>
-          )}
-          {output.toolCalls && (
-            <div className="space-y-1">
-              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                {t('requestedToolCalls')}
-              </p>
-              <Payload value={output.toolCalls} />
-            </div>
-          )}
-        </Section>
-      )}
+      {output && <OutputSection output={output} />}
 
       <Section title={t('allAttributes')}>
-        <dl className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-x-3 gap-y-1 text-[11px]">
-          {Object.entries(attributes)
-            .sort(([a], [b]) => a.localeCompare(b))
-            .map(([key, value]) => (
-              <div key={key} className="contents">
-                <dt className="break-all font-mono text-muted-foreground">
-                  {key}
-                </dt>
-                <dd className="break-all font-mono">
-                  {typeof value === 'string' ? value : JSON.stringify(value)}
-                </dd>
-              </div>
-            ))}
-        </dl>
+        <AttributesTable attributes={attributes} />
       </Section>
     </div>
+  );
+}
+
+/** A value worth putting on a row, or `null` when there is nothing to say. */
+function asText(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+/**
+ * The token counts, with cached input shown only when there was any.
+ *
+ * `netNewInput` rather than raw input: a cache read is not a prompt the model
+ * processed, and adding the two would report a number the bill does not match.
+ */
+async function TokenBreakdownList({
+  tokens,
+}: {
+  tokens: NonNullable<ReturnType<typeof tokenBreakdown>>;
+}) {
+  const t = await getTranslations('agents.spanDetail');
+  const format = await getFormatter();
+
+  return (
+    <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1 text-xs">
+      <dt className="text-muted-foreground">{t('inputTokens')}</dt>
+      <dd className="font-mono tabular-nums">
+        {format.number(tokens.netNewInput)}
+      </dd>
+      {tokens.cached > 0 && (
+        <>
+          <dt className="text-muted-foreground">{t('cachedTokens')}</dt>
+          <dd className="font-mono tabular-nums">
+            {format.number(tokens.cached)}
+          </dd>
+        </>
+      )}
+      <dt className="text-muted-foreground">{t('outputTokens')}</dt>
+      <dd className="font-mono tabular-nums">{format.number(tokens.output)}</dd>
+      <dt className="text-muted-foreground">{t('totalTokens')}</dt>
+      <dd className="font-mono font-semibold tabular-nums">
+        {format.number(tokens.total)}
+      </dd>
+    </dl>
+  );
+}
+
+/** What the model answered: free text, a structured object, tool calls. */
+async function OutputSection({
+  output,
+}: {
+  output: NonNullable<ReturnType<typeof aiOutput>>;
+}) {
+  const t = await getTranslations('agents.spanDetail');
+
+  return (
+    <Section title={t('output')}>
+      {output.text && <Payload value={output.text} />}
+      {output.object && (
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {t('responseObject')}
+          </p>
+          <Payload value={output.object} />
+        </div>
+      )}
+      {output.toolCalls && (
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {t('requestedToolCalls')}
+          </p>
+          <Payload value={output.toolCalls} />
+        </div>
+      )}
+    </Section>
+  );
+}
+
+/** Every attribute as sent, sorted, as the escape hatch for the rest. */
+function AttributesTable({
+  attributes,
+}: {
+  attributes: Record<string, unknown>;
+}) {
+  return (
+    <dl className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-x-3 gap-y-1 text-[11px]">
+      {Object.entries(attributes)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => (
+          <div key={key} className="contents">
+            <dt className="break-all font-mono text-muted-foreground">{key}</dt>
+            <dd className="break-all font-mono">
+              {typeof value === 'string' ? value : JSON.stringify(value)}
+            </dd>
+          </div>
+        ))}
+    </dl>
   );
 }

--- a/apps/webview-ui/src/features/agent-trace/ui/components/span-detail-pane.tsx
+++ b/apps/webview-ui/src/features/agent-trace/ui/components/span-detail-pane.tsx
@@ -1,0 +1,50 @@
+import type { Result, RustrakError, SpanDetail } from '@rustrak/client';
+import { getTranslations } from 'next-intl/server';
+import { AiSpanDetail } from '@/features/agent-trace/ui/components/ai-span-detail';
+import { LoadFailure } from '@/shared/ui/components/load-failure';
+
+interface SpanDetailPaneProps {
+  /** The loaded span, or `null` when no span is selected. */
+  selected: Result<SpanDetail, RustrakError> | null;
+  /** The URL named a span this trace does not contain. */
+  requestedMissing: boolean;
+}
+
+/**
+ * The right-hand pane, and the four answers it has to tell apart.
+ *
+ * The distinction that matters is between "gone" and "broken": reporting a
+ * timeout or a 500 as "that span is no longer available" would send the reader
+ * looking for a deleted span that is still there.
+ */
+export async function SpanDetailPane({
+  selected,
+  requestedMissing,
+}: SpanDetailPaneProps) {
+  const t = await getTranslations('projectPages');
+
+  const notFound =
+    selected?.success === false && selected.error.kind === 'not_found';
+
+  // A stale link, not an outage -- say so in place rather than replacing the
+  // whole trace view with a failure surface.
+  if (requestedMissing || notFound) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t('trace.spanUnavailable')}
+      </p>
+    );
+  }
+
+  if (selected == null) {
+    return (
+      <p className="text-sm text-muted-foreground">{t('trace.selectSpan')}</p>
+    );
+  }
+
+  if (!selected.success) {
+    return <LoadFailure error={selected.error} title={t('trace.loadFailed')} />;
+  }
+
+  return <AiSpanDetail span={selected.data} />;
+}

--- a/apps/webview-ui/src/features/agent-trace/ui/components/trace-summary-badges.tsx
+++ b/apps/webview-ui/src/features/agent-trace/ui/components/trace-summary-badges.tsx
@@ -1,0 +1,68 @@
+import { getFormatter, getTranslations } from 'next-intl/server';
+import type { TraceSummary } from '@/features/agent-trace/model/trace-summary';
+import { Badge } from '@/shared/ui/components/shadcn/badge';
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/**
+ * What the trace cost, in one line.
+ *
+ * Every count except tokens is hidden at zero: "0 tool calls" on a trace that
+ * never used a tool is a fact about nothing. Tokens always show, because zero
+ * tokens on an agent trace is itself worth seeing.
+ */
+export async function TraceSummaryBadges({
+  summary,
+}: {
+  summary: TraceSummary;
+}) {
+  const t = await getTranslations('projectPages');
+  const format = await getFormatter();
+
+  const { duration, totalTokens, llmCallCount, toolCallCount, errorCount } =
+    summary;
+
+  return (
+    <div className="mt-2 flex items-center gap-2 flex-wrap text-sm">
+      <span className="font-mono font-semibold">
+        {formatDuration(duration)}
+      </span>
+
+      <Badge variant="secondary">
+        {t('trace.tokens', { count: format.number(totalTokens) })}
+      </Badge>
+
+      {llmCallCount > 0 && (
+        <Badge variant="outline">
+          {t('trace.llmCalls', { count: llmCallCount })}
+        </Badge>
+      )}
+      {toolCallCount > 0 && (
+        <Badge variant="outline">
+          {t('trace.toolCalls', { count: toolCallCount })}
+        </Badge>
+      )}
+      {errorCount > 0 && (
+        <Badge variant="destructive">
+          {t('trace.errors', { count: errorCount })}
+        </Badge>
+      )}
+
+      {summary.models.map((model) => (
+        <Badge key={model} variant="outline" className="font-mono">
+          {model}
+        </Badge>
+      ))}
+
+      {summary.startedAt != null && (
+        <span className="text-xs text-muted-foreground">
+          {format.dateTime(new Date(summary.startedAt), 'precise')}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/webview-ui/src/features/alert/lib/credentials.test.ts
+++ b/apps/webview-ui/src/features/alert/lib/credentials.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { filledCredentials } from './credentials';
+
+describe('filledCredentials', () => {
+  it('keeps every field the user actually filled in', () => {
+    expect(
+      filledCredentials({ url: 'https://example.test', secret: 's3cret' }),
+    ).toEqual({ url: 'https://example.test', secret: 's3cret' });
+  });
+
+  it('drops an empty string, which means "leave the stored value alone"', () => {
+    expect(filledCredentials({ method: 'bot_token', token: '' })).toEqual({
+      method: 'bot_token',
+    });
+  });
+
+  it('treats whitespace as blank', () => {
+    expect(filledCredentials({ token: '   ' })).toEqual({});
+  });
+
+  it('drops undefined, which an optional input reports as untouched', () => {
+    expect(
+      filledCredentials({ url: 'https://a.test', secret: undefined }),
+    ).toEqual({ url: 'https://a.test' });
+  });
+
+  it('keeps a non-string value even when it is falsy', () => {
+    expect(filledCredentials({ smtp_port: 0, verify_tls: false })).toEqual({
+      smtp_port: 0,
+      verify_tls: false,
+    });
+  });
+
+  it('returns a new object rather than mutating the input', () => {
+    const input = { token: '' };
+    expect(filledCredentials(input)).not.toBe(input);
+    expect(input).toEqual({ token: '' });
+  });
+});

--- a/apps/webview-ui/src/features/alert/lib/credentials.ts
+++ b/apps/webview-ui/src/features/alert/lib/credentials.ts
@@ -1,0 +1,28 @@
+/**
+ * The credential fields the user actually filled in.
+ *
+ * Every integration dialog reads a blank input as "leave the stored value
+ * alone" rather than "clear it". The server never returns a Slack bot token or
+ * an SMTP password, so those fields start empty on edit and staying empty is
+ * the absence of new information, not an instruction: posting `''` would
+ * overwrite a working secret with nothing.
+ *
+ * Whitespace counts as blank. A token of three spaces is a paste that went
+ * wrong in every case these forms have, and the server rejects it anyway.
+ *
+ * Only strings are judged. `0` and `false` are answers, and an SMTP port of
+ * zero has to reach the server so it can say what is wrong with it.
+ */
+export function filledCredentials(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const filled: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value == null) continue;
+    if (typeof value === 'string' && value.trim() === '') continue;
+    filled[key] = value;
+  }
+
+  return filled;
+}

--- a/apps/webview-ui/src/features/alert/lib/routing.test.ts
+++ b/apps/webview-ui/src/features/alert/lib/routing.test.ts
@@ -188,6 +188,24 @@ describe('validateRoutingForIntegration', () => {
     ).toBe('routing.invalidOverrideUrl');
   });
 
+  /**
+   * A prefix test passed these: they start with the right characters and are
+   * still not addresses, so the save succeeded and the failure only surfaced
+   * later as a notification that never arrived.
+   */
+  it.each(['https://', 'http://', 'https:// invalid', 'https://?'])(
+    'rejects the malformed override URL %j',
+    (url) => {
+      expect(
+        validateRoutingForIntegration(
+          integration('webhook', { url: 'https://a.test' }),
+          { url },
+          t,
+        ),
+      ).toBe('routing.invalidOverrideUrl');
+    },
+  );
+
   it('accepts an http override URL', () => {
     expect(
       validateRoutingForIntegration(

--- a/apps/webview-ui/src/features/alert/lib/routing.test.ts
+++ b/apps/webview-ui/src/features/alert/lib/routing.test.ts
@@ -1,0 +1,298 @@
+import type { AlertIntegration, ProviderType } from '@rustrak/client';
+import { describe, expect, it } from 'vitest';
+import type { Translate } from '@/shared/lib/error-copy';
+import {
+  buildChannelsPayload,
+  readRoutingOverride,
+  routingNeedsOf,
+  validateRoutingForIntegration,
+} from './routing';
+
+/** The key, so a test asserts which reason was given rather than its copy. */
+const t: Translate = (key) => key;
+
+function integration(
+  provider_type: ProviderType,
+  credentials: Record<string, unknown> = {},
+  id = 1,
+): AlertIntegration {
+  return {
+    id,
+    name: `${provider_type} #${id}`,
+    provider_type,
+    credentials,
+    is_enabled: true,
+    failure_count: 0,
+    last_failure_at: null,
+    last_failure_message: null,
+    last_success_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as AlertIntegration;
+}
+
+describe('routingNeedsOf', () => {
+  it('asks a Slack bot for a channel and nothing else', () => {
+    expect(
+      routingNeedsOf(integration('slack', { method: 'bot_token' })),
+    ).toEqual({
+      needsChannel: true,
+      needsRecipients: false,
+      needsUrl: false,
+      hasRoutingFields: true,
+    });
+  });
+
+  it('asks a Slack incoming webhook for nothing: the URL is the channel', () => {
+    expect(routingNeedsOf(integration('slack', { method: 'webhook' }))).toEqual(
+      {
+        needsChannel: false,
+        needsRecipients: false,
+        needsUrl: false,
+        hasRoutingFields: false,
+      },
+    );
+  });
+
+  it('treats a Slack integration with no method as an incoming webhook', () => {
+    expect(routingNeedsOf(integration('slack')).needsChannel).toBe(false);
+  });
+
+  it('always asks email for recipients', () => {
+    expect(routingNeedsOf(integration('email'))).toEqual({
+      needsChannel: false,
+      needsRecipients: true,
+      needsUrl: false,
+      hasRoutingFields: true,
+    });
+  });
+
+  it('requires a URL from a webhook that carries none', () => {
+    expect(routingNeedsOf(integration('webhook'))).toEqual({
+      needsChannel: false,
+      needsRecipients: false,
+      needsUrl: true,
+      hasRoutingFields: true,
+    });
+  });
+
+  it('offers but does not require a URL when the webhook already has one', () => {
+    const needs = routingNeedsOf(
+      integration('webhook', { url: 'https://a.test' }),
+    );
+    expect(needs.needsUrl).toBe(false);
+    expect(needs.hasRoutingFields).toBe(true);
+  });
+});
+
+describe('validateRoutingForIntegration', () => {
+  it('rejects a Slack bot with no channel', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('slack', { method: 'bot_token' }),
+        {},
+        t,
+      ),
+    ).toBe('routing.slackChannelRequired');
+  });
+
+  it('rejects a Slack bot whose channel is only whitespace', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('slack', { method: 'bot_token' }),
+        { channel: '   ' },
+        t,
+      ),
+    ).toBe('routing.slackChannelRequired');
+  });
+
+  it('accepts a Slack bot with a channel', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('slack', { method: 'bot_token' }),
+        { channel: '#alerts' },
+        t,
+      ),
+    ).toBeNull();
+  });
+
+  it('accepts a Slack incoming webhook with no routing at all', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('slack', { method: 'webhook' }),
+        {},
+        t,
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects email with no recipients', () => {
+    expect(validateRoutingForIntegration(integration('email'), {}, t)).toBe(
+      'routing.recipientsRequired',
+    );
+  });
+
+  it('rejects a recipients line that parses to nothing', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('email'),
+        { recipients: ' , ' },
+        t,
+      ),
+    ).toBe('routing.invalidRecipients');
+  });
+
+  it('rejects a recipient that is not an address', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('email'),
+        { recipients: 'ops@a.test, not-an-address' },
+        t,
+      ),
+    ).toBe('routing.invalidRecipients');
+  });
+
+  it('accepts a comma-separated recipients line', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('email'),
+        { recipients: 'ops@a.test, sre@a.test' },
+        t,
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects a webhook with neither a stored nor an override URL', () => {
+    expect(validateRoutingForIntegration(integration('webhook'), {}, t)).toBe(
+      'routing.webhookUrlRequired',
+    );
+  });
+
+  it('accepts a webhook whose URL comes from its credentials', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('webhook', { url: 'https://a.test' }),
+        {},
+        t,
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects an override URL that is not http(s)', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('webhook', { url: 'https://a.test' }),
+        { url: 'ftp://a.test' },
+        t,
+      ),
+    ).toBe('routing.invalidOverrideUrl');
+  });
+
+  it('accepts an http override URL', () => {
+    expect(
+      validateRoutingForIntegration(
+        integration('webhook'),
+        { url: 'http://a.test' },
+        t,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('buildChannelsPayload', () => {
+  it('sends a trimmed channel for a Slack bot', () => {
+    const slack = integration('slack', { method: 'bot_token' }, 7);
+    expect(
+      buildChannelsPayload([7], { 7: { channel: ' #alerts ' } }, [slack]),
+    ).toEqual([
+      { integration_id: 7, routing_override: { channel: '#alerts' } },
+    ]);
+  });
+
+  it('sends nothing for a Slack incoming webhook, even with a channel typed', () => {
+    const slack = integration('slack', { method: 'webhook' }, 7);
+    expect(
+      buildChannelsPayload([7], { 7: { channel: '#alerts' } }, [slack]),
+    ).toEqual([{ integration_id: 7, routing_override: {} }]);
+  });
+
+  it('splits email recipients into the list the API expects', () => {
+    const email = integration('email', {}, 3);
+    expect(
+      buildChannelsPayload(
+        [3],
+        { 3: { recipients: 'ops@a.test, , sre@a.test' } },
+        [email],
+      ),
+    ).toEqual([
+      {
+        integration_id: 3,
+        routing_override: { recipients: ['ops@a.test', 'sre@a.test'] },
+      },
+    ]);
+  });
+
+  it('omits a blank override rather than clearing the stored value', () => {
+    const webhook = integration('webhook', { url: 'https://a.test' }, 5);
+    expect(buildChannelsPayload([5], { 5: { url: '' } }, [webhook])).toEqual([
+      { integration_id: 5, routing_override: {} },
+    ]);
+  });
+
+  it('skips a selected id no integration matches', () => {
+    expect(
+      buildChannelsPayload([99], {}, [integration('email', {}, 3)]),
+    ).toEqual([]);
+  });
+});
+
+describe('readRoutingOverride', () => {
+  it('joins an email recipients list back into the line the input binds to', () => {
+    expect(
+      readRoutingOverride(integration('email'), {
+        recipients: ['ops@a.test', 'sre@a.test'],
+      }),
+    ).toEqual({ recipients: 'ops@a.test, sre@a.test' });
+  });
+
+  it('reads nothing for email when recipients is not a list', () => {
+    expect(
+      readRoutingOverride(integration('email'), { recipients: 'x' }),
+    ).toEqual({});
+  });
+
+  it('passes a Slack channel through', () => {
+    expect(
+      readRoutingOverride(integration('slack', { method: 'bot_token' }), {
+        channel: '#alerts',
+      }),
+    ).toEqual({ channel: '#alerts' });
+  });
+
+  it('drops a non-string override value, which no input could hold', () => {
+    expect(
+      readRoutingOverride(integration('webhook'), {
+        url: 'https://a.test',
+        retries: 3,
+      }),
+    ).toEqual({ url: 'https://a.test' });
+  });
+
+  it('falls back to plain string fields when the integration is gone', () => {
+    expect(readRoutingOverride(undefined, { channel: '#alerts' })).toEqual({
+      channel: '#alerts',
+    });
+  });
+
+  it('round-trips what buildChannelsPayload wrote', () => {
+    const email = integration('email', {}, 3);
+    const [channel] = buildChannelsPayload(
+      [3],
+      { 3: { recipients: 'ops@a.test, sre@a.test' } },
+      [email],
+    );
+    expect(readRoutingOverride(email, channel.routing_override)).toEqual({
+      recipients: 'ops@a.test, sre@a.test',
+    });
+  });
+});

--- a/apps/webview-ui/src/features/alert/lib/routing.ts
+++ b/apps/webview-ui/src/features/alert/lib/routing.ts
@@ -1,4 +1,4 @@
-import type { AlertIntegration } from '@rustrak/client';
+import type { AlertIntegration, ProviderType } from '@rustrak/client';
 import type { Translate } from '@/shared/lib/error-copy';
 
 /**
@@ -10,6 +10,15 @@ import type { Translate } from '@/shared/lib/error-copy';
  */
 export type RoutingMap = Record<number, Record<string, string>>;
 
+/** Which routing inputs a channel shows, and which of them it insists on. */
+export interface RoutingNeeds {
+  needsChannel: boolean;
+  needsRecipients: boolean;
+  needsUrl: boolean;
+  /** Whether the channel shows a routing section at all. */
+  hasRoutingFields: boolean;
+}
+
 export function getSlackMethod(integration: AlertIntegration): string {
   return (
     ((integration.credentials as Record<string, unknown>).method as string) ??
@@ -18,35 +27,197 @@ export function getSlackMethod(integration: AlertIntegration): string {
 }
 
 /**
- * Which routing inputs a channel has to show, derived from the integration
- * rather than from the provider name alone.
+ * Everything one provider knows about routing, in one place.
  *
- * A webhook that already carries a URL in its credentials still offers the
- * override field, but does not require it; one that does not, requires it.
- * That distinction is the reason this is a function and not a lookup table.
+ * The three questions below used to be three `provider_type` chains in three
+ * functions, which meant a new provider was three edits in three places and
+ * nothing failed if only two of them happened. Keyed by `ProviderType`, a
+ * provider added to the client is a type error here until it answers all
+ * three.
  */
-export function routingNeedsOf(integration: AlertIntegration): {
-  needsChannel: boolean;
-  needsRecipients: boolean;
-  needsUrl: boolean;
-  hasRoutingFields: boolean;
-} {
-  const isSlackBot =
-    integration.provider_type === 'slack' &&
-    getSlackMethod(integration) === 'bot_token';
-  const needsRecipients = integration.provider_type === 'email';
-  const credUrl = (integration.credentials as Record<string, unknown>).url as
+interface RoutingBehaviour {
+  /** Which override inputs to render for this integration. */
+  needs: (integration: AlertIntegration) => RoutingNeeds;
+  /** Why this routing cannot be saved, as a message, or `null`. */
+  validate: (
+    integration: AlertIntegration,
+    routing: Record<string, string>,
+    t: Translate,
+  ) => string | null;
+  /** What the API should store, with anything blank left out. */
+  override: (
+    integration: AlertIntegration,
+    routing: Record<string, string>,
+  ) => Record<string, unknown>;
+  /** The inverse of `override`: a stored override, as the inputs hold it. */
+  read: (override: Record<string, unknown>) => Record<string, string>;
+}
+
+/**
+ * The default read: every override value an input could actually hold.
+ *
+ * Anything else stored under that channel is a field this build does not
+ * render, and putting a number or an object into a text input would only lose
+ * it on the next save.
+ */
+const stringFields = (
+  override: Record<string, unknown>,
+): Record<string, string> => {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(override)) {
+    if (typeof value === 'string') fields[key] = value;
+  }
+  return fields;
+};
+
+const isBlank = (value: string | undefined): boolean =>
+  value == null || value.trim() === '';
+
+const isHttpUrl = (url: string): boolean =>
+  url.startsWith('http://') || url.startsWith('https://');
+
+const storedUrl = (integration: AlertIntegration): string | undefined =>
+  (integration.credentials as Record<string, unknown>).url as
     | string
     | undefined;
-  const needsUrl = integration.provider_type === 'webhook' && !credUrl;
 
-  return {
-    needsChannel: isSlackBot,
-    needsRecipients,
-    needsUrl,
-    hasRoutingFields:
-      isSlackBot || needsRecipients || integration.provider_type === 'webhook',
-  };
+/** The comma-separated line the input holds, as the list the API wants. */
+const recipientList = (line: string): string[] =>
+  line
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean);
+
+/**
+ * An incoming webhook already names its channel in the URL; only a bot token
+ * can be pointed anywhere, so only a bot token has anything to route.
+ */
+const slackRouting: RoutingBehaviour = {
+  needs: (integration) => {
+    const isBot = getSlackMethod(integration) === 'bot_token';
+    return {
+      needsChannel: isBot,
+      needsRecipients: false,
+      needsUrl: false,
+      hasRoutingFields: isBot,
+    };
+  },
+
+  validate: (integration, routing, t) => {
+    if (getSlackMethod(integration) !== 'bot_token') return null;
+    if (isBlank(routing.channel)) {
+      return t('routing.slackChannelRequired', { name: integration.name });
+    }
+    return null;
+  },
+
+  override: (integration, routing) => {
+    if (getSlackMethod(integration) !== 'bot_token') return {};
+    if (!routing.channel) return {};
+    return { channel: routing.channel.trim() };
+  },
+
+  read: stringFields,
+};
+
+/** An SMTP account is a sender, never a destination: the rule supplies those. */
+const emailRouting: RoutingBehaviour = {
+  needs: () => ({
+    needsChannel: false,
+    needsRecipients: true,
+    needsUrl: false,
+    hasRoutingFields: true,
+  }),
+
+  validate: (integration, routing, t) => {
+    const name = integration.name;
+    if (isBlank(routing.recipients)) {
+      return t('routing.recipientsRequired', { name });
+    }
+
+    // A line of commas parses to nothing, and an entry with no `@` is a typo
+    // the server would only discover at send time.
+    const addresses = recipientList(routing.recipients);
+    if (addresses.length === 0 || addresses.some((a) => !a.includes('@'))) {
+      return t('routing.invalidRecipients', { name });
+    }
+    return null;
+  },
+
+  override: (_integration, routing) =>
+    routing.recipients ? { recipients: recipientList(routing.recipients) } : {},
+
+  // The one provider whose override is not a string on the wire: a list there,
+  // a comma-joined line in the input.
+  read: (override): Record<string, string> => {
+    const recipients = override.recipients;
+    if (!Array.isArray(recipients)) return {};
+    return { recipients: recipients.join(', ') };
+  },
+};
+
+/**
+ * A webhook that already carries a URL in its credentials still offers the
+ * override field, but does not require it; one that does not, requires it.
+ */
+const webhookRouting: RoutingBehaviour = {
+  needs: (integration) => ({
+    needsChannel: false,
+    needsRecipients: false,
+    needsUrl: !storedUrl(integration),
+    hasRoutingFields: true,
+  }),
+
+  validate: (integration, routing, t) => {
+    const name = integration.name;
+    const routeUrl = routing.url?.trim();
+
+    if (!storedUrl(integration) && !routeUrl) {
+      return t('routing.webhookUrlRequired', { name });
+    }
+    if (routeUrl && !isHttpUrl(routeUrl)) {
+      return t('routing.invalidOverrideUrl', { name });
+    }
+    return null;
+  },
+
+  override: (_integration, routing) =>
+    routing.url ? { url: routing.url.trim() } : {},
+
+  read: stringFields,
+};
+
+const ROUTING_BEHAVIOUR: Record<ProviderType, RoutingBehaviour> = {
+  slack: slackRouting,
+  email: emailRouting,
+  webhook: webhookRouting,
+};
+
+const behaviourOf = (integration: AlertIntegration): RoutingBehaviour =>
+  ROUTING_BEHAVIOUR[integration.provider_type];
+
+/**
+ * Which routing inputs a channel has to show, derived from the integration
+ * rather than from the provider name alone.
+ */
+export function routingNeedsOf(integration: AlertIntegration): RoutingNeeds {
+  return behaviourOf(integration).needs(integration);
+}
+
+/**
+ * A stored `routing_override`, in the one-string-per-field shape the inputs
+ * bind to.
+ *
+ * `integration` is optional because a rule can outlive the integration it
+ * points at: the channel is still in the rule, and its override still has to
+ * render rather than vanish while the user is looking at it.
+ */
+export function readRoutingOverride(
+  integration: AlertIntegration | undefined,
+  override: Record<string, unknown>,
+): Record<string, string> {
+  const read = integration ? behaviourOf(integration).read : stringFields;
+  return read(override);
 }
 
 export function validateRoutingForIntegration(
@@ -54,52 +225,7 @@ export function validateRoutingForIntegration(
   routing: Record<string, string>,
   t: Translate,
 ): string | null {
-  if (integration.provider_type === 'slack') {
-    if (getSlackMethod(integration) === 'bot_token') {
-      if (!routing.channel || routing.channel.trim() === '') {
-        return t('routing.slackChannelRequired', {
-          name: integration.name,
-        });
-      }
-    }
-  }
-  if (integration.provider_type === 'email') {
-    if (!routing.recipients || routing.recipients.trim() === '') {
-      return t('routing.recipientsRequired', {
-        name: integration.name,
-      });
-    }
-    const addrs = routing.recipients
-      .split(',')
-      .map((a) => a.trim())
-      .filter(Boolean);
-    if (addrs.length === 0 || addrs.some((a) => !a.includes('@'))) {
-      return t('routing.invalidRecipients', {
-        name: integration.name,
-      });
-    }
-  }
-  if (integration.provider_type === 'webhook') {
-    const credUrl = (integration.credentials as Record<string, unknown>).url as
-      | string
-      | undefined;
-    const routeUrl = routing.url?.trim();
-    if (!credUrl && !routeUrl) {
-      return t('routing.webhookUrlRequired', {
-        name: integration.name,
-      });
-    }
-    if (
-      routeUrl &&
-      !routeUrl.startsWith('http://') &&
-      !routeUrl.startsWith('https://')
-    ) {
-      return t('routing.invalidOverrideUrl', {
-        name: integration.name,
-      });
-    }
-  }
-  return null;
+  return behaviourOf(integration).validate(integration, routing, t);
 }
 
 /**
@@ -119,16 +245,19 @@ export function collectRoutingErrors(
   // configured integration, so the pair is quadratic without it.
   const byId = new Map(integrations.map((i) => [i.id, i]));
   const errors: Record<number, string> = {};
+
   for (const id of selectedIds) {
     const integration = byId.get(id);
     if (!integration) continue;
-    const err = validateRoutingForIntegration(
+
+    const error = validateRoutingForIntegration(
       integration,
       routingMap[id] ?? {},
       t,
     );
-    if (err) errors[id] = err;
+    if (error) errors[id] = error;
   }
+
   return errors;
 }
 
@@ -144,28 +273,20 @@ export function buildChannelsPayload(
   routingMap: RoutingMap,
   integrations: readonly AlertIntegration[],
 ): { integration_id: number; routing_override: Record<string, unknown> }[] {
+  const byId = new Map(integrations.map((i) => [i.id, i]));
+
   return selectedIds.flatMap((id) => {
-    const routing = routingMap[id] ?? {};
-    const integration = integrations.find((i) => i.id === id);
+    const integration = byId.get(id);
     if (!integration) return [];
-    const routingOverride: Record<string, unknown> = {};
 
-    if (
-      integration.provider_type === 'slack' &&
-      getSlackMethod(integration) === 'bot_token'
-    ) {
-      if (routing.channel) routingOverride.channel = routing.channel.trim();
-    }
-    if (integration.provider_type === 'email' && routing.recipients) {
-      routingOverride.recipients = routing.recipients
-        .split(',')
-        .map((a) => a.trim())
-        .filter(Boolean);
-    }
-    if (integration.provider_type === 'webhook' && routing.url) {
-      routingOverride.url = routing.url.trim();
-    }
-
-    return [{ integration_id: id, routing_override: routingOverride }];
+    return [
+      {
+        integration_id: id,
+        routing_override: behaviourOf(integration).override(
+          integration,
+          routingMap[id] ?? {},
+        ),
+      },
+    ];
   });
 }

--- a/apps/webview-ui/src/features/alert/lib/routing.ts
+++ b/apps/webview-ui/src/features/alert/lib/routing.ts
@@ -73,8 +73,23 @@ const stringFields = (
 const isBlank = (value: string | undefined): boolean =>
   value == null || value.trim() === '';
 
-const isHttpUrl = (url: string): boolean =>
-  url.startsWith('http://') || url.startsWith('https://');
+/**
+ * A URL a dispatcher could actually POST to.
+ *
+ * Parsed rather than prefix-matched: `https://` on its own, and anything with
+ * a space in the authority, start with the right characters and are still not
+ * addresses. A prefix test passes them through to the save, and the failure
+ * surfaces later as a delivery that never arrives.
+ */
+const isHttpUrl = (url: string): boolean => {
+  let protocol: string;
+  try {
+    protocol = new URL(url).protocol;
+  } catch {
+    return false;
+  }
+  return protocol === 'http:' || protocol === 'https:';
+};
 
 const storedUrl = (integration: AlertIntegration): string | undefined =>
   (integration.credentials as Record<string, unknown>).url as

--- a/apps/webview-ui/src/features/alert/model/integration-forms.test.ts
+++ b/apps/webview-ui/src/features/alert/model/integration-forms.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { Translate } from '@/shared/lib/error-copy';
+import { slackFormSchema } from './integration-forms';
+
+/** The key, so a test asserts which reason was given rather than its copy. */
+const t: Translate = (key) => key;
+
+const schema = slackFormSchema(t);
+
+/** `[path, message]` for the first issue, or `null` when it parsed. */
+function firstIssue(input: Record<string, unknown>): [string, string] | null {
+  const result = schema.safeParse(input);
+  if (result.success) return null;
+  const issue = result.error.issues[0];
+  return [issue.path.join('.'), issue.message];
+}
+
+const webhook = (webhook_url: string) => ({
+  name: 'Slack',
+  method: 'webhook',
+  is_edit: false,
+  webhook_url,
+  token: '',
+  is_enabled: true,
+});
+
+const bot = (token: string, is_edit: boolean) => ({
+  name: 'Slack',
+  method: 'bot_token',
+  is_edit,
+  webhook_url: '',
+  token,
+  is_enabled: true,
+});
+
+describe('slackFormSchema, incoming webhook', () => {
+  it('requires a URL', () => {
+    expect(firstIssue(webhook(''))).toEqual([
+      'webhook_url',
+      'validation.webhookUrlRequired',
+    ]);
+  });
+
+  it('treats a whitespace URL as missing', () => {
+    expect(firstIssue(webhook('   '))).toEqual([
+      'webhook_url',
+      'validation.webhookUrlRequired',
+    ]);
+  });
+
+  it('rejects something that is not a URL at all', () => {
+    expect(firstIssue(webhook('not a url'))).toEqual([
+      'webhook_url',
+      'validation.validUrl',
+    ]);
+  });
+
+  it('rejects a non-Slack host', () => {
+    expect(firstIssue(webhook('https://example.test/services/x'))).toEqual([
+      'webhook_url',
+      'validation.slackWebhookUrl',
+    ]);
+  });
+
+  it('rejects plain http on the Slack host', () => {
+    expect(firstIssue(webhook('http://hooks.slack.com/services/x'))).toEqual([
+      'webhook_url',
+      'validation.slackWebhookUrl',
+    ]);
+  });
+
+  it('accepts a real Slack webhook URL', () => {
+    expect(
+      firstIssue(webhook('https://hooks.slack.com/services/T/B/x')),
+    ).toBeNull();
+  });
+});
+
+describe('slackFormSchema, bot token', () => {
+  it('requires a token when creating', () => {
+    expect(firstIssue(bot('', false))).toEqual([
+      'token',
+      'validation.botTokenRequired',
+    ]);
+  });
+
+  it('treats a whitespace token as missing when creating', () => {
+    expect(firstIssue(bot('   ', false))).toEqual([
+      'token',
+      'validation.botTokenRequired',
+    ]);
+  });
+
+  it('accepts a blank token when editing: it means keep the stored one', () => {
+    expect(firstIssue(bot('', true))).toBeNull();
+  });
+
+  it('rejects a token without the bot prefix', () => {
+    expect(firstIssue(bot('xoxp-1234', true))).toEqual([
+      'token',
+      'validation.botTokenPrefix',
+    ]);
+  });
+
+  it('accepts a bot token', () => {
+    expect(firstIssue(bot('xoxb-1234', false))).toBeNull();
+  });
+
+  it('ignores the webhook URL entirely when the method is bot_token', () => {
+    expect(
+      firstIssue({ ...bot('xoxb-1234', false), webhook_url: 'nonsense' }),
+    ).toBeNull();
+  });
+});
+
+describe('slackFormSchema, shared fields', () => {
+  it('requires a name whichever method is chosen', () => {
+    expect(
+      firstIssue({
+        ...webhook('https://hooks.slack.com/services/T/B/x'),
+        name: '',
+      }),
+    ).toEqual(['name', 'validation.nameRequired']);
+  });
+});

--- a/apps/webview-ui/src/features/alert/model/integration-forms.ts
+++ b/apps/webview-ui/src/features/alert/model/integration-forms.ts
@@ -58,66 +58,88 @@ export function webhookFormSchema(t: Translate) {
   });
 }
 
+/**
+ * Why this incoming-webhook URL cannot be used, or `null`.
+ *
+ * The host check is not pedantry: a well-formed URL pointing anywhere else
+ * accepts the POST and drops it, so the integration would look configured and
+ * silently deliver nothing.
+ */
+function slackWebhookUrlProblem(
+  url: string | undefined,
+  t: Translate,
+): string | null {
+  if (!url || url.trim() === '') return t('validation.webhookUrlRequired');
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return t('validation.validUrl');
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'hooks.slack.com') {
+    return t('validation.slackWebhookUrl');
+  }
+
+  return null;
+}
+
+/**
+ * Why this bot token cannot be used, or `null`.
+ *
+ * Blank while editing is the one case that is not an answer at all: the server
+ * never returns the stored token, so an untouched field means "leave it alone".
+ */
+function slackTokenProblem(
+  token: string | undefined,
+  isEdit: boolean,
+  t: Translate,
+): string | null {
+  if (!token || token.trim() === '') {
+    return isEdit ? null : t('validation.botTokenRequired');
+  }
+
+  if (!token.startsWith('xoxb-')) return t('validation.botTokenPrefix');
+
+  return null;
+}
+
 export function slackFormSchema(t: Translate) {
-  return z
-    .object({
-      name: z.string().min(1, t('validation.nameRequired')).max(255),
-      method: z.enum(['webhook', 'bot_token']),
-      is_edit: z.boolean(),
-      webhook_url: z.string().optional(),
-      token: z.string().optional(),
-      is_enabled: z.boolean(),
-    })
-    .superRefine((data, ctx) => {
-      if (data.method === 'webhook') {
-        if (!data.webhook_url || data.webhook_url.trim() === '') {
+  return (
+    z
+      .object({
+        name: z.string().min(1, t('validation.nameRequired')).max(255),
+        method: z.enum(['webhook', 'bot_token']),
+        is_edit: z.boolean(),
+        webhook_url: z.string().optional(),
+        token: z.string().optional(),
+        is_enabled: z.boolean(),
+      })
+      // The two methods are alternatives, so exactly one field is judged and at
+      // most one issue is raised: marking the input the chosen method does not
+      // use would be an error the user cannot see, let alone fix.
+      .superRefine((data, ctx) => {
+        const [path, problem] =
+          data.method === 'webhook'
+            ? ([
+                'webhook_url',
+                slackWebhookUrlProblem(data.webhook_url, t),
+              ] as const)
+            : ([
+                'token',
+                slackTokenProblem(data.token, data.is_edit, t),
+              ] as const);
+
+        if (problem) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: t('validation.webhookUrlRequired'),
-            path: ['webhook_url'],
-          });
-        } else {
-          try {
-            const url = new URL(data.webhook_url);
-            if (
-              url.protocol !== 'https:' ||
-              url.hostname !== 'hooks.slack.com'
-            ) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: t('validation.slackWebhookUrl'),
-                path: ['webhook_url'],
-              });
-            }
-          } catch {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: t('validation.validUrl'),
-              path: ['webhook_url'],
-            });
-          }
-        }
-      } else if (data.method === 'bot_token') {
-        const tokenEmpty = !data.token || data.token.trim() === '';
-        if (data.is_edit && tokenEmpty) {
-          // Blank on edit = keep existing — OK
-          return;
-        }
-        if (tokenEmpty) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: t('validation.botTokenRequired'),
-            path: ['token'],
-          });
-        } else if (!data.token!.startsWith('xoxb-')) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: t('validation.botTokenPrefix'),
-            path: ['token'],
+            message: problem,
+            path: [path],
           });
         }
-      }
-    });
+      })
+  );
 }
 
 export function emailFormSchema(t: Translate) {

--- a/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/email-form.tsx
+++ b/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/email-form.tsx
@@ -2,22 +2,17 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Play } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState, useTransition } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import {
-  createIntegration,
-  updateIntegration,
-} from '@/features/alert/api/mutations';
+import { filledCredentials } from '@/features/alert/lib/credentials';
 import {
   EMAIL_FIELD_MAP,
   type EmailFormData,
   emailDefaults,
   emailFormSchema,
 } from '@/features/alert/model/integration-forms';
-import { applyServerFieldErrors } from '@/shared/lib/form-errors';
+import { useIntegrationSubmit } from '@/features/alert/ui/hooks/use-integration-submit';
 import { Button } from '@/shared/ui/components/shadcn/button';
 import {
   DialogDescription,
@@ -49,9 +44,6 @@ export function EmailForm({
   const t = useTranslations('alerts');
 
   const globalT = useTranslations();
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const isLoading = isPending || parentPending;
   const [testRecipients, setTestRecipients] = useState('');
 
   // Parsed once so the button's enabled state and its payload can never
@@ -72,56 +64,37 @@ export function EmailForm({
     defaultValues: emailDefaults(existingIntegration),
   });
 
-  const onSubmit = (data: EmailFormData) => {
-    startTransition(async () => {
-      const credentials: Record<string, unknown> = {
+  const { submit, isPending } = useIntegrationSubmit<EmailFormData>({
+    form,
+    existingIntegration,
+    providerType: 'email',
+    credentials: (data) =>
+      filledCredentials({
         smtp_host: data.smtp_host,
         smtp_port: data.smtp_port,
         from_address: data.from_address,
-      };
-      if (data.smtp_username) credentials.smtp_username = data.smtp_username;
-      if (data.smtp_password) credentials.smtp_password = data.smtp_password;
+        smtp_username: data.smtp_username,
+        smtp_password: data.smtp_password,
+      }),
+    fieldMap: EMAIL_FIELD_MAP,
+    labels: {
+      name: t('common.fieldName'),
+      smtp_host: t('email.fieldHost'),
+      smtp_port: t('email.fieldPort'),
+      smtp_username: t('email.fieldUsername'),
+      smtp_password: t('email.fieldPassword'),
+      from_address: t('email.fieldFrom'),
+    },
+    messages: {
+      saveFailed: t('email.saveFailed'),
+      created: t('email.created'),
+      updated: t('email.updated'),
+    },
+    t: globalT,
+    onSaved: () => onOpenChange(false),
+  });
 
-      const result = existingIntegration
-        ? await updateIntegration(existingIntegration.id, {
-            name: data.name,
-            credentials,
-            is_enabled: data.is_enabled,
-          })
-        : await createIntegration({
-            name: data.name,
-            provider_type: 'email',
-            credentials,
-            is_enabled: data.is_enabled,
-          });
-
-      if (!result.success) {
-        const applied = applyServerFieldErrors(form, result.error, {
-          map: EMAIL_FIELD_MAP,
-          labels: {
-            name: t('common.fieldName'),
-            smtp_host: t('email.fieldHost'),
-            smtp_port: t('email.fieldPort'),
-            smtp_username: t('email.fieldUsername'),
-            smtp_password: t('email.fieldPassword'),
-            from_address: t('email.fieldFrom'),
-          },
-          t: globalT,
-        });
-
-        if (applied.formLevel) {
-          toast.error(t('email.saveFailed'), {
-            description: applied.formLevel,
-          });
-        }
-        return;
-      }
-
-      toast.success(t(existingIntegration ? 'email.updated' : 'email.created'));
-      onOpenChange(false);
-      router.refresh();
-    });
-  };
+  const isLoading = isPending || parentPending;
 
   return (
     <>
@@ -133,7 +106,7 @@ export function EmailForm({
       </DialogHeader>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={form.handleSubmit(submit)} className="space-y-4">
           <NameField<EmailFormData>
             placeholder={t('email.namePlaceholder')}
             disabled={isLoading}

--- a/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/slack-form.tsx
+++ b/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/slack-form.tsx
@@ -2,15 +2,10 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Play } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState, useTransition } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import {
-  createIntegration,
-  updateIntegration,
-} from '@/features/alert/api/mutations';
+import { filledCredentials } from '@/features/alert/lib/credentials';
 import {
   SLACK_FIELD_MAP,
   type SlackFormData,
@@ -18,7 +13,7 @@ import {
   slackDefaults,
   slackFormSchema,
 } from '@/features/alert/model/integration-forms';
-import { applyServerFieldErrors } from '@/shared/lib/form-errors';
+import { useIntegrationSubmit } from '@/features/alert/ui/hooks/use-integration-submit';
 import { Button } from '@/shared/ui/components/shadcn/button';
 import {
   DialogDescription,
@@ -57,9 +52,6 @@ export function SlackForm({
   const t = useTranslations('alerts');
 
   const globalT = useTranslations();
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const isLoading = isPending || parentPending;
   const [testChannel, setTestChannel] = useState('');
 
   const schema = useMemo(() => slackFormSchema(t), [t]);
@@ -70,56 +62,35 @@ export function SlackForm({
 
   const method = form.watch('method') as SlackMethod;
 
-  const onSubmit = (data: SlackFormData) => {
-    startTransition(async () => {
-      let credentials: Record<string, unknown>;
+  const { submit, isPending } = useIntegrationSubmit<SlackFormData>({
+    form,
+    existingIntegration,
+    providerType: 'slack',
+    // The two methods are alternatives, not a union of fields: an incoming
+    // webhook has no token and a bot has no webhook URL, and sending the
+    // unused one would leave the integration describing itself as both. A
+    // blank token on edit falls out of `filledCredentials`, which is what
+    // "leave the stored token alone" looks like on the wire.
+    credentials: (data) =>
+      data.method === 'webhook'
+        ? { method: 'webhook', webhook_url: data.webhook_url }
+        : filledCredentials({ method: 'bot_token', token: data.token }),
+    fieldMap: SLACK_FIELD_MAP,
+    labels: {
+      name: t('common.fieldName'),
+      webhook_url: t('slack.fieldWebhookUrl'),
+      token: t('slack.fieldToken'),
+    },
+    messages: {
+      saveFailed: t('slack.saveFailed'),
+      created: t('slack.created'),
+      updated: t('slack.updated'),
+    },
+    t: globalT,
+    onSaved: () => onOpenChange(false),
+  });
 
-      if (data.method === 'webhook') {
-        credentials = { method: 'webhook', webhook_url: data.webhook_url };
-      } else {
-        credentials = { method: 'bot_token' };
-        const tokenEmpty = !data.token || data.token.trim() === '';
-        if (!tokenEmpty) credentials.token = data.token;
-      }
-
-      const result = existingIntegration
-        ? await updateIntegration(existingIntegration.id, {
-            name: data.name,
-            credentials,
-            is_enabled: data.is_enabled,
-          })
-        : await createIntegration({
-            name: data.name,
-            provider_type: 'slack',
-            credentials,
-            is_enabled: data.is_enabled,
-          });
-
-      if (!result.success) {
-        const applied = applyServerFieldErrors(form, result.error, {
-          map: SLACK_FIELD_MAP,
-          labels: {
-            name: t('common.fieldName'),
-            webhook_url: t('slack.fieldWebhookUrl'),
-            token: t('slack.fieldToken'),
-          },
-          t: globalT,
-        });
-
-        if (applied.formLevel) {
-          toast.error(t('slack.saveFailed'), {
-            description: applied.formLevel,
-          });
-        }
-        return;
-      }
-
-      toast.success(t(existingIntegration ? 'slack.updated' : 'slack.created'));
-      onOpenChange(false);
-      router.refresh();
-    });
-  };
-
+  const isLoading = isPending || parentPending;
   const isBotToken = method === 'bot_token';
 
   return (
@@ -132,7 +103,7 @@ export function SlackForm({
       </DialogHeader>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={form.handleSubmit(submit)} className="space-y-4">
           <NameField<SlackFormData>
             placeholder={t('slack.namePlaceholder')}
             disabled={isLoading}

--- a/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/webhook-form.tsx
+++ b/apps/webview-ui/src/features/alert/ui/components/integration-config-dialog/forms/webhook-form.tsx
@@ -1,22 +1,17 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useMemo, useTransition } from 'react';
+import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import {
-  createIntegration,
-  updateIntegration,
-} from '@/features/alert/api/mutations';
+import { filledCredentials } from '@/features/alert/lib/credentials';
 import {
   WEBHOOK_FIELD_MAP,
   type WebhookFormData,
   webhookDefaults,
   webhookFormSchema,
 } from '@/features/alert/model/integration-forms';
-import { applyServerFieldErrors } from '@/shared/lib/form-errors';
+import { useIntegrationSubmit } from '@/features/alert/ui/hooks/use-integration-submit';
 import {
   DialogDescription,
   DialogHeader,
@@ -48,9 +43,6 @@ export function WebhookForm({
   const t = useTranslations('alerts');
 
   const globalT = useTranslations();
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const isLoading = isPending || parentPending;
 
   // Seeded at mount, never re-seeded. The body only exists while the dialog
   // is open (Base UI unmounts the portal after the close animation), so
@@ -63,52 +55,28 @@ export function WebhookForm({
     defaultValues: webhookDefaults(existingIntegration),
   });
 
-  const onSubmit = (data: WebhookFormData) => {
-    startTransition(async () => {
-      const credentials: Record<string, unknown> = {};
-      if (data.url && data.url.trim() !== '') credentials.url = data.url;
-      if (data.secret && data.secret.trim() !== '')
-        credentials.secret = data.secret;
+  const { submit, isPending } = useIntegrationSubmit<WebhookFormData>({
+    form,
+    existingIntegration,
+    providerType: 'webhook',
+    credentials: (data) =>
+      filledCredentials({ url: data.url, secret: data.secret }),
+    fieldMap: WEBHOOK_FIELD_MAP,
+    labels: {
+      name: t('common.fieldName'),
+      url: t('webhook.fieldUrl'),
+      secret: t('webhook.fieldSecret'),
+    },
+    messages: {
+      saveFailed: t('webhook.saveFailed'),
+      created: t('webhook.created'),
+      updated: t('webhook.updated'),
+    },
+    t: globalT,
+    onSaved: () => onOpenChange(false),
+  });
 
-      const result = existingIntegration
-        ? await updateIntegration(existingIntegration.id, {
-            name: data.name,
-            credentials,
-            is_enabled: data.is_enabled,
-          })
-        : await createIntegration({
-            name: data.name,
-            provider_type: 'webhook',
-            credentials,
-            is_enabled: data.is_enabled,
-          });
-
-      if (!result.success) {
-        const applied = applyServerFieldErrors(form, result.error, {
-          map: WEBHOOK_FIELD_MAP,
-          labels: {
-            name: t('common.fieldName'),
-            url: t('webhook.fieldUrl'),
-            secret: t('webhook.fieldSecret'),
-          },
-          t: globalT,
-        });
-
-        if (applied.formLevel) {
-          toast.error(t('webhook.saveFailed'), {
-            description: applied.formLevel,
-          });
-        }
-        return;
-      }
-
-      toast.success(
-        t(existingIntegration ? 'webhook.updated' : 'webhook.created'),
-      );
-      onOpenChange(false);
-      router.refresh();
-    });
-  };
+  const isLoading = isPending || parentPending;
 
   return (
     <>
@@ -120,7 +88,7 @@ export function WebhookForm({
       </DialogHeader>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={form.handleSubmit(submit)} className="space-y-4">
           <NameField<WebhookFormData>
             placeholder={t('webhook.namePlaceholder')}
             disabled={isLoading}

--- a/apps/webview-ui/src/features/alert/ui/components/integrations-list/integrations-list.tsx
+++ b/apps/webview-ui/src/features/alert/ui/components/integrations-list/integrations-list.tsx
@@ -13,6 +13,7 @@ import {
 import { alertProviders } from '@/features/alert/model/providers';
 import { IntegrationConfigDialog } from '@/features/alert/ui/components/integration-config-dialog/integration-config-dialog';
 import { ProviderIcon } from '@/features/alert/ui/components/provider-icon';
+import type { Translate } from '@/shared/lib/error-copy';
 import { cn } from '@/shared/lib/utils';
 import {
   AlertDialog,
@@ -174,96 +175,14 @@ export function IntegrationsList({
         </CollapsibleTrigger>
         <CollapsibleContent className="rounded-b-lg border border-t-0 bg-card/50 p-5">
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {alertProviders.map((providerDef) => {
-              const instances = getIntegrationsByType(providerDef.type);
-              const count = instances.length;
-              const single = count === 1 ? instances[0] : null;
-              const isConnected = !!single && single.is_enabled;
-              const isDisabled = !!single && !single.is_enabled;
-
-              return (
-                /* Not a <button>: the card holds its own Manage button, and a
-                   button inside a button is invalid HTML. So it takes the role
-                   and the keyboard handling a button would have given it for
-                   free — without this the card was mouse-only and unreachable
-                   by Tab. */
-                // biome-ignore lint/a11y/useSemanticElements: see above
-                <div
-                  key={providerDef.type}
-                  className={cn(
-                    'group relative bg-card border rounded-lg p-5 flex flex-col justify-between h-48',
-                    'hover:border-primary/50 transition-all cursor-pointer',
-                    count === 0 && 'opacity-70 hover:opacity-100',
-                  )}
-                  role="button"
-                  tabIndex={0}
-                  aria-label={t('integrations.configureAria', {
-                    name: providerDef.name,
-                  })}
-                  onClick={() => handleCardClick(providerDef.type)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleCardClick(providerDef.type);
-                    }
-                  }}
-                >
-                  <div className="flex justify-between items-start">
-                    <div
-                      className={cn(
-                        'size-10 rounded flex items-center justify-center text-white',
-                        providerDef.color,
-                      )}
-                    >
-                      <ProviderIcon
-                        type={providerDef.type}
-                        className="size-5"
-                      />
-                    </div>
-
-                    <div className="flex items-center gap-1.5">
-                      <Badge
-                        variant={isConnected ? 'default' : 'secondary'}
-                        className={cn(
-                          'text-[10px] font-bold uppercase tracking-wider',
-                          isConnected &&
-                            'bg-green-500/10 text-green-500 border-green-500/20 hover:bg-green-500/20',
-                          isDisabled && 'opacity-60',
-                        )}
-                      >
-                        {count === 0
-                          ? t('integrations.notConfigured')
-                          : count > 1
-                            ? t('integrations.configuredCount', { count })
-                            : isConnected
-                              ? t('integrations.connected')
-                              : t('integrations.disabled')}
-                      </Badge>
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="font-bold text-base">{providerDef.name}</h3>
-                    <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
-                      {single ? single.name : t(providerDef.descriptionKey)}
-                    </p>
-                  </div>
-
-                  <Button
-                    variant="outline"
-                    className="w-full text-xs font-bold uppercase tracking-wide"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleCardClick(providerDef.type);
-                    }}
-                  >
-                    {count === 0
-                      ? t('integrations.configure')
-                      : t('integrations.manage')}
-                  </Button>
-                </div>
-              );
-            })}
+            {alertProviders.map((providerDef) => (
+              <ProviderCard
+                key={providerDef.type}
+                providerDef={providerDef}
+                instances={getIntegrationsByType(providerDef.type)}
+                onOpen={handleCardClick}
+              />
+            ))}
           </div>
         </CollapsibleContent>
       </Collapsible>
@@ -321,6 +240,126 @@ export function IntegrationsList({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+    </div>
+  );
+}
+
+/** What a provider's tile has to say, from the integrations it holds. */
+interface ProviderStatus {
+  count: number;
+  /**
+   * The one integration this provider has, or `null`.
+   *
+   * A tile with several has room for a count and nothing else, so it cannot
+   * name one or report whether it is on.
+   */
+  single: AlertIntegration | null;
+  isConnected: boolean;
+  isDisabled: boolean;
+}
+
+function providerStatus(
+  instances: readonly AlertIntegration[],
+): ProviderStatus {
+  const count = instances.length;
+  const single = count === 1 ? (instances[0] ?? null) : null;
+
+  return {
+    count,
+    single,
+    isConnected: !!single && single.is_enabled,
+    isDisabled: !!single && !single.is_enabled,
+  };
+}
+
+function statusLabel(status: ProviderStatus, t: Translate): string {
+  if (status.count === 0) return t('integrations.notConfigured');
+  if (status.count > 1) {
+    return t('integrations.configuredCount', { count: status.count });
+  }
+  return status.isConnected
+    ? t('integrations.connected')
+    : t('integrations.disabled');
+}
+
+interface ProviderCardProps {
+  providerDef: (typeof alertProviders)[number];
+  instances: readonly AlertIntegration[];
+  onOpen: (type: ProviderType) => void;
+}
+
+/** One provider tile: its mark, its state, and the way into its dialog. */
+function ProviderCard({ providerDef, instances, onOpen }: ProviderCardProps) {
+  const t = useTranslations('alerts');
+  const status = providerStatus(instances);
+  const open = () => onOpen(providerDef.type);
+
+  return (
+    /* Not a <button>: the card holds its own Manage button, and a button
+       inside a button is invalid HTML. So it takes the role and the keyboard
+       handling a button would have given it for free — without this the card
+       was mouse-only and unreachable by Tab. */
+    // biome-ignore lint/a11y/useSemanticElements: see above
+    <div
+      className={cn(
+        'group relative bg-card border rounded-lg p-5 flex flex-col justify-between h-48',
+        'hover:border-primary/50 transition-all cursor-pointer',
+        status.count === 0 && 'opacity-70 hover:opacity-100',
+      )}
+      role="button"
+      tabIndex={0}
+      aria-label={t('integrations.configureAria', { name: providerDef.name })}
+      onClick={open}
+      onKeyDown={(e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        e.preventDefault();
+        open();
+      }}
+    >
+      <div className="flex justify-between items-start">
+        <div
+          className={cn(
+            'size-10 rounded flex items-center justify-center text-white',
+            providerDef.color,
+          )}
+        >
+          <ProviderIcon type={providerDef.type} className="size-5" />
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Badge
+            variant={status.isConnected ? 'default' : 'secondary'}
+            className={cn(
+              'text-[10px] font-bold uppercase tracking-wider',
+              status.isConnected &&
+                'bg-green-500/10 text-green-500 border-green-500/20 hover:bg-green-500/20',
+              status.isDisabled && 'opacity-60',
+            )}
+          >
+            {statusLabel(status, t)}
+          </Badge>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-bold text-base">{providerDef.name}</h3>
+        <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
+          {status.single ? status.single.name : t(providerDef.descriptionKey)}
+        </p>
+      </div>
+
+      <Button
+        variant="outline"
+        className="w-full text-xs font-bold uppercase tracking-wide"
+        onClick={(e) => {
+          e.stopPropagation();
+          open();
+        }}
+      >
+        {status.count === 0
+          ? t('integrations.configure')
+          : t('integrations.manage')}
+      </Button>
     </div>
   );
 }

--- a/apps/webview-ui/src/features/alert/ui/hooks/use-channel-routing.ts
+++ b/apps/webview-ui/src/features/alert/ui/hooks/use-channel-routing.ts
@@ -6,35 +6,32 @@ import { useState } from 'react';
 import {
   collectRoutingErrors,
   type RoutingMap,
+  readRoutingOverride,
 } from '@/features/alert/lib/routing';
 
 /**
  * The routing overrides an existing rule already carries, flattened into the
- * one-string-per-field shape the inputs bind to. Email is special-cased
- * because its `recipients` is a list on the wire and a comma-joined line in
- * the UI.
+ * one-string-per-field shape the inputs bind to.
+ *
+ * How to flatten one override is the provider's own business, so it is asked
+ * rather than decided here: see `readRoutingOverride`.
  */
 function initialRoutingMap(
   existingRule: AlertRule | null,
   integrations: readonly AlertIntegration[],
 ): RoutingMap {
   if (!existingRule) return {};
+
   const byId = new Map(integrations.map((i) => [i.id, i]));
   const map: RoutingMap = {};
-  for (const ch of existingRule.channels) {
-    const override = ch.routing_override ?? {};
-    const integration = byId.get(ch.integration_id);
-    const normalized: Record<string, string> = {};
-    if (integration?.provider_type === 'email') {
-      const r = override.recipients;
-      if (Array.isArray(r)) normalized.recipients = r.join(', ');
-    } else {
-      for (const [k, v] of Object.entries(override)) {
-        if (typeof v === 'string') normalized[k] = v;
-      }
-    }
-    map[ch.integration_id] = normalized;
+
+  for (const channel of existingRule.channels) {
+    map[channel.integration_id] = readRoutingOverride(
+      byId.get(channel.integration_id),
+      channel.routing_override ?? {},
+    );
   }
+
   return map;
 }
 

--- a/apps/webview-ui/src/features/alert/ui/hooks/use-integration-submit.ts
+++ b/apps/webview-ui/src/features/alert/ui/hooks/use-integration-submit.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import type {
+  AlertIntegration,
+  CreateAlertIntegration,
+  Result,
+  RustrakError,
+} from '@rustrak/client';
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
+import { toast } from 'sonner';
+import {
+  createIntegration,
+  updateIntegration,
+} from '@/features/alert/api/mutations';
+import type { Translate } from '@/shared/lib/error-copy';
+import {
+  applyServerFieldErrors,
+  type ServerFieldMap,
+} from '@/shared/lib/form-errors';
+
+/**
+ * The two fields every integration dialog collects, whatever the provider.
+ *
+ * Everything else a form holds is provider-specific and reaches the server
+ * folded into `credentials`, which is why the constraint stops here.
+ */
+export interface IntegrationFormBase extends FieldValues {
+  name: string;
+  is_enabled: boolean;
+}
+
+/**
+ * Already-translated copy, not message keys.
+ *
+ * Resolving at the call site is deliberate: it keeps every `t('slack.created')`
+ * a string literal, which is the only form the message-keys architecture rule
+ * can check. A key assembled here from `providerType` would type-check, render
+ * correctly, and be invisible to the rule that catches it going stale.
+ */
+export interface IntegrationSubmitMessages {
+  readonly saveFailed: string;
+  readonly created: string;
+  readonly updated: string;
+}
+
+export interface UseIntegrationSubmitOptions<T extends IntegrationFormBase> {
+  readonly form: UseFormReturn<T>;
+  /** `null` while creating; the record being edited otherwise. */
+  readonly existingIntegration: AlertIntegration | null;
+  readonly providerType: CreateAlertIntegration['provider_type'];
+  /** The flat inputs, folded into the one opaque object the server stores. */
+  readonly credentials: (data: T) => Record<string, unknown>;
+  /** Server dot path -> the name this form registers. */
+  readonly fieldMap: ServerFieldMap;
+  /** Human label per form field, so error copy reads in the user's words. */
+  readonly labels: Readonly<Record<string, string>>;
+  readonly messages: IntegrationSubmitMessages;
+  /** The global translator, which `applyServerFieldErrors` needs for its copy. */
+  readonly t: Translate;
+  /** Run after a save the server accepted, before the route refreshes. */
+  readonly onSaved: () => void;
+}
+
+export interface IntegrationSubmit<T extends IntegrationFormBase> {
+  readonly submit: (data: T) => void;
+  readonly isPending: boolean;
+}
+
+/**
+ * Create-or-update for one alert integration, with its failure handling.
+ *
+ * The webhook, email and Slack dialogs differ only in which inputs they render
+ * and what those inputs are called; the save itself is one sequence for all
+ * three: fold the credentials, post to create or update, mark the offending
+ * inputs on rejection, and on success announce it, close and refresh. That
+ * sequence lived three times, and the copies had already drifted apart in how
+ * they decided a credential was blank.
+ */
+export function useIntegrationSubmit<T extends IntegrationFormBase>(
+  options: UseIntegrationSubmitOptions<T>,
+): IntegrationSubmit<T> {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const submit = (data: T) => {
+    startTransition(async () => {
+      const result = await save(options, data);
+
+      if (!result.success) {
+        reportFailure(options, result.error);
+        return;
+      }
+
+      const { existingIntegration, messages, onSaved } = options;
+      toast.success(existingIntegration ? messages.updated : messages.created);
+      onSaved();
+      router.refresh();
+    });
+  };
+
+  return { submit, isPending };
+}
+
+/**
+ * Update where there is something to update, create otherwise.
+ *
+ * `provider_type` is only sent on create: it is what the integration *is*, and
+ * the update endpoint does not accept a change of it.
+ */
+function save<T extends IntegrationFormBase>(
+  options: UseIntegrationSubmitOptions<T>,
+  data: T,
+): Promise<Result<AlertIntegration, RustrakError>> {
+  const { existingIntegration, providerType, credentials } = options;
+  const body = {
+    name: data.name,
+    credentials: credentials(data),
+    is_enabled: data.is_enabled,
+  };
+
+  return existingIntegration
+    ? updateIntegration(existingIntegration.id, body)
+    : createIntegration({ ...body, provider_type: providerType });
+}
+
+/** Put the rejection where the user can act on it. */
+function reportFailure<T extends IntegrationFormBase>(
+  options: UseIntegrationSubmitOptions<T>,
+  error: RustrakError,
+): void {
+  const { form, fieldMap, labels, messages, t } = options;
+  const applied = applyServerFieldErrors(form, error, {
+    map: fieldMap,
+    labels,
+    t,
+  });
+
+  // A toast beside an input that already carries the reason is noise. Only a
+  // failure that named no field of this dialog needs one.
+  if (applied.formLevel) {
+    toast.error(messages.saveFailed, { description: applied.formLevel });
+  }
+}

--- a/apps/webview-ui/src/features/event/lib/event-jumps.test.ts
+++ b/apps/webview-ui/src/features/event/lib/event-jumps.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { type EventJumpFlags, eventJumpTargets } from './event-jumps';
+
+const nothing: EventJumpFlags = {
+  threads: false,
+  stackTrace: false,
+  breadcrumbs: false,
+  contexts: false,
+  modules: false,
+  user: false,
+  tags: false,
+};
+
+describe('eventJumpTargets', () => {
+  it('always offers highlights: every event has some', () => {
+    expect(eventJumpTargets(nothing)).toEqual(['highlights']);
+  });
+
+  it('lists sections in the order the page renders them', () => {
+    expect(
+      eventJumpTargets({
+        ...nothing,
+        tags: true,
+        stackTrace: true,
+        breadcrumbs: true,
+        user: true,
+      }),
+    ).toEqual(['highlights', 'stacktrace', 'breadcrumbs', 'tags', 'context']);
+  });
+
+  /**
+   * Contexts, modules and the user render together under one heading, so they
+   * share one anchor: three entries pointing at the same `#context` would read
+   * as three places to go and arrive at one.
+   */
+  it('gives contexts, modules and user a single shared anchor', () => {
+    expect(eventJumpTargets({ ...nothing, modules: true })).toEqual([
+      'highlights',
+      'context',
+    ]);
+    expect(
+      eventJumpTargets({
+        ...nothing,
+        contexts: true,
+        modules: true,
+        user: true,
+      }),
+    ).toEqual(['highlights', 'context']);
+  });
+
+  it('omits a section the event has nothing for', () => {
+    expect(eventJumpTargets({ ...nothing, tags: true })).toEqual([
+      'highlights',
+      'tags',
+    ]);
+  });
+});

--- a/apps/webview-ui/src/features/event/lib/event-jumps.ts
+++ b/apps/webview-ui/src/features/event/lib/event-jumps.ts
@@ -1,0 +1,33 @@
+import type { readEventPayload } from '@/features/event/lib/event-payload';
+
+/** The "does this event have anything to show here?" flags. */
+export type EventJumpFlags = ReturnType<typeof readEventPayload>['has'];
+
+/** An anchor the "jump to" strip can offer. */
+export type EventJumpTarget =
+  | 'highlights'
+  | 'stacktrace'
+  | 'breadcrumbs'
+  | 'tags'
+  | 'context';
+
+/**
+ * The sections this event actually has, in render order.
+ *
+ * An anchor to a section that is not on the page is worse than no anchor: it
+ * scrolls nowhere and reads as a broken page rather than as an event that
+ * simply carried no breadcrumbs.
+ */
+export function eventJumpTargets(has: EventJumpFlags): EventJumpTarget[] {
+  const targets: EventJumpTarget[] = ['highlights'];
+
+  if (has.stackTrace) targets.push('stacktrace');
+  if (has.breadcrumbs) targets.push('breadcrumbs');
+  if (has.tags) targets.push('tags');
+
+  // One anchor for three panels: contexts, modules and the user render
+  // together under a single heading.
+  if (has.contexts || has.modules || has.user) targets.push('context');
+
+  return targets;
+}

--- a/apps/webview-ui/src/features/project/lib/setup-snippet.test.ts
+++ b/apps/webview-ui/src/features/project/lib/setup-snippet.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSetupSnippet } from './setup-snippet';
+
+const DSN = 'https://key@rustrak.test/1';
+
+describe('resolveSetupSnippet', () => {
+  it('renders the platform snippet with the project DSN filled in', () => {
+    const setup = resolveSetupSnippet('javascript-react', DSN);
+
+    expect(setup.codeExample).toContain(DSN);
+    expect(setup.docsUrl).toBeDefined();
+  });
+
+  it('falls back to a browser example when no platform is set', () => {
+    // A project that has never ingested an event has no platform, and the
+    // generic browser snippet is the one that fits every such case.
+    const setup = resolveSetupSnippet(null, DSN);
+
+    expect(setup.codeExample).toContain('@sentry/browser');
+    expect(setup.codeExample).toContain(DSN);
+  });
+
+  /**
+   * The rule the whole function exists for. Snippet coverage is partial by
+   * design and the platforms it misses are mostly console and native ones
+   * (unreal, playstation, xbox, native...), where a `@sentry/browser` example
+   * is actively misleading. Sentry is stricter still, rendering an explicit
+   * "currently unavailable" rather than substituting another platform's.
+   */
+  it('offers no example for a platform it has no snippet for', () => {
+    const setup = resolveSetupSnippet('playstation', DSN);
+
+    expect(setup.codeExample).toBeUndefined();
+    expect(setup.snippet).toBeUndefined();
+  });
+
+  it('defaults the language when the snippet does not name one', () => {
+    expect(resolveSetupSnippet(null, DSN).codeLanguage).toBe('javascript');
+  });
+});

--- a/apps/webview-ui/src/features/project/lib/setup-snippet.ts
+++ b/apps/webview-ui/src/features/project/lib/setup-snippet.ts
@@ -1,0 +1,54 @@
+import {
+  PLATFORM_DOCS,
+  PLATFORM_SNIPPETS,
+  renderSnippet,
+} from '@/shared/config/platform-snippets';
+
+/** The generic example for a project that has never named a platform. */
+const browserExample = (
+  dsn: string,
+) => `import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "${dsn}",
+});`;
+
+export interface SetupSnippet {
+  snippet: (typeof PLATFORM_SNIPPETS)[string] | undefined;
+  docsUrl: string | undefined;
+  /** Absent when this platform has no example worth showing. */
+  codeExample: string | undefined;
+  codeLanguage: string;
+}
+
+/**
+ * The setup instructions for one project, following its own platform.
+ *
+ * Only a project with no platform at all (never set, no event ingested yet)
+ * gets the generic browser example. A project that **has** a platform but no
+ * snippet must never get it: snippet coverage is partial by design, and the
+ * platforms it misses are mostly console and native ones (unreal, playstation,
+ * xbox, native...) where a `@sentry/browser` example is actively misleading.
+ * Sentry does the same, and more strictly: `sdkDocumentation.tsx` renders an
+ * explicit "currently unavailable" rather than substituting another
+ * platform's snippet.
+ */
+export function resolveSetupSnippet(
+  platform: string | null | undefined,
+  dsn: string,
+): SetupSnippet {
+  const snippet = platform ? PLATFORM_SNIPPETS[platform] : undefined;
+
+  const codeExample = snippet
+    ? renderSnippet(snippet.configure, dsn)
+    : platform
+      ? undefined
+      : browserExample(dsn);
+
+  return {
+    snippet,
+    docsUrl: platform ? PLATFORM_DOCS[platform] : undefined,
+    codeExample,
+    codeLanguage: snippet?.language ?? 'javascript',
+  };
+}

--- a/apps/webview-ui/src/features/project/ui/components/client-keys-settings.tsx
+++ b/apps/webview-ui/src/features/project/ui/components/client-keys-settings.tsx
@@ -4,15 +4,13 @@ import type { Project } from '@rustrak/client';
 import { Check, Copy, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { resolveSetupSnippet } from '@/features/project/lib/setup-snippet';
+import { useCopyFlags } from '@/features/project/ui/hooks/use-copy-flags';
 import {
-  PLATFORM_DOCS,
-  PLATFORM_SNIPPETS,
-  renderSnippet,
-} from '@/shared/config/platform-snippets';
+  type SyntaxHighlighter,
+  useSyntaxHighlighter,
+} from '@/features/project/ui/hooks/use-syntax-highlighter';
 import { platformLabel } from '@/shared/config/platforms';
-import { copyToClipboard } from '@/shared/lib/clipboard';
 import { SettingSection } from '@/shared/ui/components/setting-row';
 import { Button } from '@/shared/ui/components/shadcn/button';
 
@@ -20,93 +18,22 @@ interface ClientKeysSettingsProps {
   project: Project;
 }
 
-type HighlighterComponent = typeof import('react-syntax-highlighter').Prism;
-type HighlighterStyle = Record<string, React.CSSProperties>;
-
 export function ClientKeysSettings({ project }: ClientKeysSettingsProps) {
   const t = useTranslations('projects');
   const { resolvedTheme } = useTheme();
-  const [copiedDsn, setCopiedDsn] = useState(false);
-  const [copiedCode, setCopiedCode] = useState(false);
-  const [copiedInstall, setCopiedInstall] = useState(false);
-  const [Highlighter, setHighlighter] = useState<HighlighterComponent | null>(
-    null,
-  );
-  const [highlighterStyle, setHighlighterStyle] =
-    useState<HighlighterStyle | null>(null);
-  const [highlighterFailed, setHighlighterFailed] = useState(false);
   const isDark = resolvedTheme === 'dark';
 
-  async function copy(
-    value: string,
-    setFlag: (copied: boolean) => void,
-    label: string,
-  ) {
-    if (!(await copyToClipboard(value))) {
-      toast.info(t('copyUnavailable'), {
-        description: t('copyUnavailableHint', { label }),
-      });
-      return;
-    }
-    setFlag(true);
-    setTimeout(() => setFlag(false), 2000);
-  }
+  const highlighter = useSyntaxHighlighter(isDark);
+  const { isCopied, copy } = useCopyFlags({
+    unavailable: t('copyUnavailable'),
+    hint: (label) => t('copyUnavailableHint', { label }),
+  });
 
-  // Loaded lazily: the highlighter is far larger than this page's own code,
-  // and the DSN above it stays useful while it arrives.
-  useEffect(() => {
-    let cancelled = false;
-    Promise.all([
-      import('react-syntax-highlighter').then((mod) => mod.Prism),
-      import('react-syntax-highlighter/dist/esm/styles/prism'),
-    ])
-      .then(([component, styles]) => {
-        if (cancelled) return;
-        setHighlighter(() => component);
-        setHighlighterStyle(
-          (isDark ? styles.vscDarkPlus : styles.vs) as HighlighterStyle,
-        );
-      })
-      .catch(() => {
-        // Chunk failed to load. Fall back to the plain <pre> below rather than
-        // spinning forever, and don't leave the rejection unhandled.
-        if (!cancelled) setHighlighterFailed(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isDark]);
+  const { snippet, docsUrl, codeExample, codeLanguage } = resolveSetupSnippet(
+    project.platform,
+    project.dsn,
+  );
 
-  // Setup instructions follow the project's own platform. Only a project with
-  // no platform at all (never set, no event ingested yet) gets the generic
-  // browser example.
-  //
-  // A project that HAS a platform but no snippet must never get it: snippet
-  // coverage is partial by design, and the platforms it misses are mostly
-  // console and native ones (unreal, playstation, xbox, native...) where a
-  // `@sentry/browser` example is actively misleading. Sentry does the same,
-  // and more strictly: `sdkDocumentation.tsx` renders an explicit "currently
-  // unavailable" error rather than substituting another platform's snippet.
-  const snippet = project.platform
-    ? PLATFORM_SNIPPETS[project.platform]
-    : undefined;
-  const docsUrl = project.platform
-    ? PLATFORM_DOCS[project.platform]
-    : undefined;
-
-  // Absent for a selected platform we have no snippet for. The DSN section and
-  // the docs link carry the page on their own, which is what Sentry falls back
-  // to for its deprecated platforms (`deprecatedPlatformInfo.tsx`).
-  const codeExample = snippet
-    ? renderSnippet(snippet.configure, project.dsn)
-    : project.platform
-      ? undefined
-      : `import * as Sentry from "@sentry/browser";
-
-Sentry.init({
-  dsn: "${project.dsn}",
-});`;
-  const codeLanguage = snippet?.language ?? 'javascript';
   const exampleTitle = snippet
     ? t('clientKeys.examplePlatform', {
         platform: platformLabel(project.platform ?? ''),
@@ -126,11 +53,11 @@ Sentry.init({
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => copy(project.dsn, setCopiedDsn, t('clientKeys.dsn'))}
+            onClick={() => copy('dsn', project.dsn, t('clientKeys.dsn'))}
             className="shrink-0"
             aria-label={t('clientKeys.copyDsn')}
           >
-            {copiedDsn ? (
+            {isCopied('dsn') ? (
               <Check className="size-4 text-primary" />
             ) : (
               <Copy className="size-4" />
@@ -153,15 +80,15 @@ Sentry.init({
               size="sm"
               onClick={() =>
                 copy(
+                  'install',
                   snippet.install ?? '',
-                  setCopiedInstall,
                   t('clientKeys.commandLabel'),
                 )
               }
               className="shrink-0"
               aria-label={t('clientKeys.copyInstallCommand')}
             >
-              {copiedInstall ? (
+              {isCopied('install') ? (
                 <Check className="size-4 text-primary" />
               ) : (
                 <Copy className="size-4" />
@@ -171,89 +98,157 @@ Sentry.init({
         </SettingSection>
       )}
 
-      <SettingSection
-        title={codeExample ? exampleTitle : t('clientKeys.setup')}
-        description={
-          codeExample ? t('clientKeys.dsnFilled') : t('clientKeys.pointSdk')
+      <SetupSection
+        exampleTitle={exampleTitle}
+        codeExample={codeExample}
+        codeLanguage={codeLanguage}
+        docsUrl={docsUrl}
+        platform={project.platform}
+        highlighter={highlighter}
+        onCopy={() =>
+          codeExample && copy('code', codeExample, t('clientKeys.exampleLabel'))
         }
-      >
-        <div className="mt-3">
-          {codeExample && (
-            <>
-              <div className="mb-2 flex justify-end">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() =>
-                    copy(
-                      codeExample,
-                      setCopiedCode,
-                      t('clientKeys.exampleLabel'),
-                    )
-                  }
-                  className="h-6 text-xs"
-                >
-                  {copiedCode ? (
-                    <>
-                      <Check className="mr-1 size-3 text-primary" />
-                      {t('clientKeys.copied')}
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="mr-1 size-3" />
-                      {t('clientKeys.copy')}
-                    </>
-                  )}
-                </Button>
-              </div>
-              <div className="overflow-hidden overflow-x-auto rounded-lg border">
-                {Highlighter && highlighterStyle ? (
-                  <Highlighter
-                    language={codeLanguage}
-                    style={highlighterStyle}
-                    customStyle={{
-                      margin: 0,
-                      padding: '1rem',
-                      fontSize: '0.75rem',
-                      background: isDark ? '#1e1e1e' : '#ffffff',
-                    }}
-                  >
-                    {codeExample}
-                  </Highlighter>
-                ) : highlighterFailed ? (
-                  <pre className="overflow-x-auto p-4 font-mono text-xs">
-                    {codeExample}
-                  </pre>
+        copied={isCopied('code')}
+      />
+    </div>
+  );
+}
+
+interface SetupSectionProps {
+  exampleTitle: string;
+  /** Absent for a platform this build has no snippet for. */
+  codeExample: string | undefined;
+  codeLanguage: string;
+  docsUrl: string | undefined;
+  platform: string | null;
+  highlighter: SyntaxHighlighter;
+  onCopy: () => void;
+  copied: boolean;
+}
+
+/**
+ * The setup snippet, and the docs link that stands in for it.
+ *
+ * The link is the one part that always renders: a platform with no snippet
+ * still has documentation, and it is the whole of what this section can offer
+ * such a project.
+ */
+function SetupSection({
+  exampleTitle,
+  codeExample,
+  codeLanguage,
+  docsUrl,
+  platform,
+  highlighter,
+  onCopy,
+  copied,
+}: SetupSectionProps) {
+  const t = useTranslations('projects');
+
+  return (
+    <SettingSection
+      title={codeExample ? exampleTitle : t('clientKeys.setup')}
+      description={
+        codeExample ? t('clientKeys.dsnFilled') : t('clientKeys.pointSdk')
+      }
+    >
+      <div className="mt-3">
+        {codeExample && (
+          <>
+            <div className="mb-2 flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onCopy}
+                className="h-6 text-xs"
+              >
+                {copied ? (
+                  <>
+                    <Check className="mr-1 size-3 text-primary" />
+                    {t('clientKeys.copied')}
+                  </>
                 ) : (
-                  <div className="flex h-24 animate-pulse items-center justify-center bg-muted p-4">
-                    <Loader2 className="size-4 animate-spin text-muted-foreground" />
-                  </div>
+                  <>
+                    <Copy className="mr-1 size-3" />
+                    {t('clientKeys.copy')}
+                  </>
                 )}
-              </div>
-            </>
-          )}
-          <p
-            className={`text-xs text-muted-foreground${codeExample ? ' mt-3' : ''}`}
+              </Button>
+            </div>
+            <div className="overflow-hidden overflow-x-auto rounded-lg border">
+              <CodeBlock
+                code={codeExample}
+                language={codeLanguage}
+                highlighter={highlighter}
+              />
+            </div>
+          </>
+        )}
+
+        <p
+          className={`text-xs text-muted-foreground${codeExample ? ' mt-3' : ''}`}
+        >
+          {t('clientKeys.compatLead')}{' '}
+          <a
+            href={docsUrl ?? 'https://docs.sentry.io/platforms/'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
           >
-            {t('clientKeys.compatLead')}{' '}
-            <a
-              href={docsUrl ?? 'https://docs.sentry.io/platforms/'}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:underline"
-            >
-              {docsUrl
-                ? t('clientKeys.docsPlatform', {
-                    platform: platformLabel(project.platform ?? ''),
-                  })
-                : t('clientKeys.docsSentry')}
-            </a>{' '}
-            {codeExample
-              ? t('clientKeys.compatFull')
-              : t('clientKeys.compatSteps')}
-          </p>
-        </div>
-      </SettingSection>
+            {docsUrl
+              ? t('clientKeys.docsPlatform', {
+                  platform: platformLabel(platform ?? ''),
+                })
+              : t('clientKeys.docsSentry')}
+          </a>{' '}
+          {codeExample
+            ? t('clientKeys.compatFull')
+            : t('clientKeys.compatSteps')}
+        </p>
+      </div>
+    </SettingSection>
+  );
+}
+
+/**
+ * The example, highlighted where the highlighter arrived.
+ *
+ * Three states, and the third is why `failed` exists: a chunk that never
+ * loaded must fall back to readable plain text, not shimmer forever.
+ */
+function CodeBlock({
+  code,
+  language,
+  highlighter: { Highlighter, style, failed, background },
+}: {
+  code: string;
+  language: string;
+  highlighter: SyntaxHighlighter;
+}) {
+  if (Highlighter && style) {
+    return (
+      <Highlighter
+        language={language}
+        style={style}
+        customStyle={{
+          margin: 0,
+          padding: '1rem',
+          fontSize: '0.75rem',
+          background,
+        }}
+      >
+        {code}
+      </Highlighter>
+    );
+  }
+
+  if (failed) {
+    return <pre className="overflow-x-auto p-4 font-mono text-xs">{code}</pre>;
+  }
+
+  return (
+    <div className="flex h-24 animate-pulse items-center justify-center bg-muted p-4">
+      <Loader2 className="size-4 animate-spin text-muted-foreground" />
     </div>
   );
 }

--- a/apps/webview-ui/src/features/project/ui/hooks/use-copy-flags.ts
+++ b/apps/webview-ui/src/features/project/ui/hooks/use-copy-flags.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { copyToClipboard } from '@/shared/lib/clipboard';
+
+export interface CopyFlags {
+  /** Whether this target was copied within the last couple of seconds. */
+  isCopied: (target: string) => boolean;
+  copy: (target: string, value: string, label: string) => Promise<void>;
+}
+
+interface CopyMessages {
+  /** Shown when the clipboard is unavailable, with the hint below it. */
+  unavailable: string;
+  hint: (label: string) => string;
+}
+
+/**
+ * "Copied" ticks, one per copyable thing on a page.
+ *
+ * A set rather than one "most recently copied" value: the ticks are
+ * independent, so copying the install command must not silently un-tick the
+ * DSN the reader copied a moment earlier.
+ *
+ * A clipboard that refuses says so. `navigator.clipboard` is unavailable over
+ * plain HTTP, which is exactly how a self-hosted install is often reached, and
+ * a button that quietly does nothing there is worse than one that explains.
+ */
+export function useCopyFlags(messages: CopyMessages): CopyFlags {
+  const [copied, setCopied] = useState<ReadonlySet<string>>(new Set());
+
+  const copy = async (target: string, value: string, label: string) => {
+    if (!(await copyToClipboard(value))) {
+      toast.info(messages.unavailable, { description: messages.hint(label) });
+      return;
+    }
+
+    setCopied((prev) => new Set(prev).add(target));
+    setTimeout(() => {
+      setCopied((prev) => {
+        const next = new Set(prev);
+        next.delete(target);
+        return next;
+      });
+    }, 2000);
+  };
+
+  return { isCopied: (target) => copied.has(target), copy };
+}

--- a/apps/webview-ui/src/features/project/ui/hooks/use-syntax-highlighter.ts
+++ b/apps/webview-ui/src/features/project/ui/hooks/use-syntax-highlighter.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type HighlighterComponent = typeof import('react-syntax-highlighter').Prism;
+type HighlighterStyle = Record<string, React.CSSProperties>;
+
+export interface SyntaxHighlighter {
+  /** `null` until the chunk arrives, and forever if it never does. */
+  Highlighter: HighlighterComponent | null;
+  style: HighlighterStyle | null;
+  /** The chunk failed. Render the code as plain text rather than spinning. */
+  failed: boolean;
+  /**
+   * The canvas the chosen style expects, as a literal.
+   *
+   * Paired with `style` here rather than read off the theme at the call site:
+   * the two are picked by the same `isDark`, and letting them be decided in
+   * two places is how a dark block ends up on a white card mid theme-switch.
+   */
+  background: string;
+}
+
+/**
+ * The syntax highlighter, loaded lazily.
+ *
+ * It is far larger than the page's own code and the DSN above it stays useful
+ * while it arrives, so it is never part of the first payload.
+ *
+ * A failed chunk is reported rather than swallowed: without `failed` the page
+ * would show a loading shimmer for a load that already ended, and the reader
+ * would wait for a snippet that is never coming.
+ */
+export function useSyntaxHighlighter(isDark: boolean): SyntaxHighlighter {
+  const [Highlighter, setHighlighter] = useState<HighlighterComponent | null>(
+    null,
+  );
+  const [style, setStyle] = useState<HighlighterStyle | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([
+      import('react-syntax-highlighter').then((mod) => mod.Prism),
+      import('react-syntax-highlighter/dist/esm/styles/prism'),
+    ])
+      .then(([component, styles]) => {
+        if (cancelled) return;
+        setHighlighter(() => component);
+        setStyle((isDark ? styles.vscDarkPlus : styles.vs) as HighlighterStyle);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isDark]);
+
+  return {
+    Highlighter,
+    style,
+    failed,
+    background: isDark ? '#1e1e1e' : '#ffffff',
+  };
+}

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
@@ -1,0 +1,87 @@
+import type { TransactionDetail } from '@rustrak/client';
+import { describe, expect, it } from 'vitest';
+import { readTransactionPayload } from './transaction-payload';
+
+function txn(over: Partial<TransactionDetail> = {}): TransactionDetail {
+  return {
+    id: 't1',
+    transaction_name: 'GET /',
+    duration_ms: 12,
+    timestamp: '2026-01-01T00:00:10.000Z',
+    start_timestamp: '2026-01-01T00:00:00.000Z',
+    data: {},
+    ...over,
+  } as unknown as TransactionDetail;
+}
+
+describe('readTransactionPayload', () => {
+  it('reads the trace context, its op and its status', () => {
+    const payload = readTransactionPayload(
+      txn({
+        data: { contexts: { trace: { op: 'http.server', status: 'ok' } } },
+      }),
+    );
+
+    expect(payload.op).toBe('http.server');
+    expect(payload.status).toBe('ok');
+    expect(payload.trace).toEqual({ op: 'http.server', status: 'ok' });
+  });
+
+  it('ignores an op or status that is not a string', () => {
+    const payload = readTransactionPayload(
+      txn({ data: { contexts: { trace: { op: 7, status: null } } } }),
+    );
+
+    expect(payload.op).toBeUndefined();
+    expect(payload.status).toBeUndefined();
+  });
+
+  it('treats a missing trace context as absent rather than empty', () => {
+    expect(readTransactionPayload(txn()).trace).toBeUndefined();
+  });
+
+  it('rejects an array where an object is expected', () => {
+    // `typeof [] === 'object'`, so a payload with `tags: []` would otherwise
+    // render an empty key/value panel instead of nothing.
+    expect(readTransactionPayload(txn({ data: { tags: [] } })).tags).toBeNull();
+  });
+
+  it('reads spans only when the payload holds a list', () => {
+    expect(
+      readTransactionPayload(txn({ data: { spans: [{}, {}] } })).spans,
+    ).toHaveLength(2);
+    expect(
+      readTransactionPayload(txn({ data: { spans: 'nope' } })).spans,
+    ).toEqual([]);
+  });
+
+  it('prefers the payload epoch seconds over the row timestamps', () => {
+    const payload = readTransactionPayload(
+      txn({ data: { start_timestamp: 1000, timestamp: 1002 } }),
+    );
+
+    expect(payload.transactionStart).toBe(1000);
+    expect(payload.transactionEnd).toBe(1002);
+  });
+
+  it('falls back to the row timestamps when the payload has none', () => {
+    // The SDK sends epoch seconds; the row stores ISO. The waterfall's clock
+    // is in seconds, so a fallback has to be converted, not passed through.
+    const payload = readTransactionPayload(txn());
+
+    expect(payload.transactionStart).toBe(
+      Date.parse('2026-01-01T00:00:00.000Z') / 1000,
+    );
+    expect(payload.transactionEnd).toBe(
+      Date.parse('2026-01-01T00:00:10.000Z') / 1000,
+    );
+  });
+
+  it('falls back to the end timestamp when the row has no start', () => {
+    const payload = readTransactionPayload(txn({ start_timestamp: null }));
+
+    expect(payload.transactionStart).toBe(
+      Date.parse('2026-01-01T00:00:10.000Z') / 1000,
+    );
+  });
+});

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
@@ -1,0 +1,75 @@
+import type { TransactionDetail } from '@rustrak/client';
+import type { Span, TraceContext } from '@/features/transaction/model/span';
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  // `typeof [] === 'object'`, and a list is never one of the key/value panels
+  // this reads, so an array is not an object here.
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * A moment on the waterfall's clock, which counts seconds.
+ *
+ * The SDK sends epoch seconds inside the payload; the row stores ISO strings.
+ * The fallback has to be converted rather than passed through, or every bar
+ * would be placed a thousand times too far along.
+ */
+function epochSeconds(raw: unknown, fallbackIso: string): number {
+  if (typeof raw === 'number') return raw;
+  return Date.parse(fallbackIso) / 1000;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Everything the transaction detail page reads out of the stored payload. */
+export interface TransactionPayload {
+  trace: TraceContext | undefined;
+  spans: Span[];
+  measurements: Record<string, unknown> | null;
+  tags: Record<string, unknown> | null;
+  request: Record<string, unknown> | null;
+  user: Record<string, unknown> | null;
+  /** Epoch seconds, the left edge of the waterfall. */
+  transactionStart: number;
+  /** Epoch seconds, its right edge. */
+  transactionEnd: number;
+  op: string | undefined;
+  status: string | undefined;
+}
+
+/**
+ * The stored event payload, narrowed into the shapes the page renders.
+ *
+ * `data` is whatever the SDK sent, so every read here is a question about an
+ * `unknown`. Doing it once, in one place, is what keeps those questions out of
+ * the page and provable on their own.
+ */
+export function readTransactionPayload(
+  txn: TransactionDetail,
+): TransactionPayload {
+  const data = (txn.data ?? {}) as Record<string, unknown>;
+  const trace = asObject(asObject(data.contexts)?.trace) ?? undefined;
+
+  return {
+    trace: trace as TraceContext | undefined,
+    spans: Array.isArray(data.spans) ? (data.spans as Span[]) : [],
+    measurements: asObject(data.measurements),
+    tags: asObject(data.tags),
+    request: asObject(data.request),
+    user: asObject(data.user),
+
+    transactionStart: epochSeconds(
+      data.start_timestamp,
+      txn.start_timestamp ?? txn.timestamp,
+    ),
+    transactionEnd: epochSeconds(data.timestamp, txn.timestamp),
+
+    op: asString(trace?.op),
+    status: asString(trace?.status),
+  };
+}

--- a/apps/webview-ui/src/features/transaction/ui/components/span-waterfall.tsx
+++ b/apps/webview-ui/src/features/transaction/ui/components/span-waterfall.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { type KeyboardEvent, useMemo, useState } from 'react';
 import type { Span, TraceContext } from '@/features/transaction/model/span';
 import { cn } from '@/shared/lib/utils';
+import { barGeometry } from '@/shared/lib/waterfall-geometry';
 
 interface SpanWaterfallProps {
   spans: Span[];
@@ -243,126 +244,144 @@ export function SpanWaterfall({
           </span>
         </div>
 
-        {rows.map(
-          ({ span, depth, hasChildren, collapsed: isCol, selfMs }, i) => {
-            const dur = spanDuration(span);
-            const start = span.start_timestamp;
-            const offsetPct =
-              start != null && total > 0
-                ? ((start - traceStart) / total) * 100
-                : 0;
-            const widthPct =
-              dur != null && total > 0
-                ? Math.max(0.5, (dur / 1000 / total) * 100)
-                : 0;
-            const clampedWidth = Math.min(widthPct, 100 - offsetPct);
-            const failed = span.status && span.status !== 'ok';
-            const isSelected =
-              span.span_id != null && selected === span.span_id;
-
-            const selectKey = (e: KeyboardEvent) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                setSelected(isSelected ? null : (span.span_id ?? null));
-              }
-            };
-
-            return (
-              // `span_id` is the key wherever the span has one. The index is
-              // the fallback for a span the SDK sent without an id, which
-              // nothing else can distinguish.
-              // react-doctor-disable-next-line react-doctor/no-array-index-as-key
-              <div key={span.span_id ?? `span-${i}`}>
-                {/* biome-ignore lint/a11y/useSemanticElements: the row contains
-                    its own collapse <button>, and a <button> nested inside a
-                    <button> is invalid HTML. */}
-                <div
-                  role="button"
-                  tabIndex={0}
-                  onClick={() =>
-                    setSelected(isSelected ? null : (span.span_id ?? null))
-                  }
-                  onKeyDown={selectKey}
-                  className={cn(
-                    'flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1 text-left hover:bg-muted/40',
-                    isSelected && 'bg-muted/50',
-                  )}
-                >
-                  <div
-                    className="flex w-[38%] min-w-0 items-center gap-1"
-                    style={{ paddingLeft: `${Math.min(depth, 8) * 12}px` }}
-                  >
-                    {hasChildren ? (
-                      // The row itself is the selectable control, and this is a
-                      // second control inside it. Nesting is unavoidable here:
-                      // the row cannot be a <button> without making this one
-                      // invalid HTML, which is why the row is a div with a
-                      // role and its own keyboard handling.
-                      // react-doctor-disable-next-line react-doctor/html-no-nested-interactive
-                      <button
-                        type="button"
-                        aria-label={
-                          isCol
-                            ? t('waterfall.expand')
-                            : t('waterfall.collapse')
-                        }
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          toggle(span.span_id);
-                        }}
-                        className="shrink-0 text-muted-foreground hover:text-foreground"
-                      >
-                        {isCol ? (
-                          <ChevronRight className="size-3" />
-                        ) : (
-                          <ChevronDown className="size-3" />
-                        )}
-                      </button>
-                    ) : (
-                      <span className="inline-block size-3 shrink-0" />
-                    )}
-                    <span
-                      className={cn(
-                        'shrink-0 rounded px-1 py-px text-[10px] font-medium text-white',
-                        opColor(span.op),
-                      )}
-                    >
-                      {span.op || t('waterfall.spanFallback')}
-                    </span>
-                    <span className="truncate text-muted-foreground">
-                      {span.description || '—'}
-                    </span>
-                    {failed && (
-                      <span className="shrink-0 rounded bg-destructive/15 px-1 text-[10px] text-destructive">
-                        {span.status}
-                      </span>
-                    )}
-                  </div>
-                  <div className="relative h-4 flex-1">
-                    <div
-                      className={cn(
-                        'absolute inset-y-0 rounded-sm',
-                        opColor(span.op),
-                      )}
-                      style={{
-                        left: `${offsetPct}%`,
-                        width: `${clampedWidth}%`,
-                      }}
-                    />
-                  </div>
-                  <span className="w-16 text-right tabular-nums text-muted-foreground">
-                    {formatDuration(dur)}
-                  </span>
-                </div>
-
-                {isSelected && (
-                  <SpanDetail span={span} dur={dur} selfMs={selfMs} />
-                )}
-              </div>
-            );
-          },
-        )}
+        {rows.map((row, i) => (
+          // `span_id` is the key wherever the span has one. The index is the
+          // fallback for a span the SDK sent without an id, which nothing else
+          // can distinguish.
+          // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+          <SpanWaterfallRow
+            key={row.span.span_id ?? `span-${i}`}
+            row={row}
+            traceStart={traceStart}
+            total={total}
+            isSelected={
+              row.span.span_id != null && selected === row.span.span_id
+            }
+            onSelect={setSelected}
+            onToggle={toggle}
+          />
+        ))}
       </div>
+    </div>
+  );
+}
+
+interface SpanWaterfallRowProps {
+  row: FlatRow;
+  /** Epoch seconds of the earliest span, the left edge of every bar's track. */
+  traceStart: number;
+  /** Span of the whole trace in seconds, the width of that track. */
+  total: number;
+  isSelected: boolean;
+  onSelect: (spanId: string | null) => void;
+  onToggle: (id?: string) => void;
+}
+
+/** One span on the shared clock, with its detail panel underneath when open. */
+function SpanWaterfallRow({
+  row,
+  traceStart,
+  total,
+  isSelected,
+  onSelect,
+  onToggle,
+}: SpanWaterfallRowProps) {
+  const t = useTranslations('transactions');
+  const { span, depth, hasChildren, collapsed: isCol, selfMs } = row;
+
+  const dur = spanDuration(span);
+  // The track counts seconds and `spanDuration` returns milliseconds.
+  const { offsetPct, widthPct } = barGeometry(
+    span.start_timestamp,
+    dur == null ? null : dur / 1000,
+    traceStart,
+    total,
+  );
+
+  const failed = span.status && span.status !== 'ok';
+  const select = () => onSelect(isSelected ? null : (span.span_id ?? null));
+
+  const selectKey = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      select();
+    }
+  };
+
+  return (
+    <div>
+      {/* biome-ignore lint/a11y/useSemanticElements: the row contains its own
+          collapse <button>, and a <button> nested inside a <button> is invalid
+          HTML. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={select}
+        onKeyDown={selectKey}
+        className={cn(
+          'flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1 text-left hover:bg-muted/40',
+          isSelected && 'bg-muted/50',
+        )}
+      >
+        <div
+          className="flex w-[38%] min-w-0 items-center gap-1"
+          style={{ paddingLeft: `${Math.min(depth, 8) * 12}px` }}
+        >
+          {hasChildren ? (
+            // The row itself is the selectable control, and this is a second
+            // control inside it. Nesting is unavoidable here: the row cannot be
+            // a <button> without making this one invalid HTML, which is why the
+            // row is a div with a role and its own keyboard handling.
+            // react-doctor-disable-next-line react-doctor/html-no-nested-interactive
+            <button
+              type="button"
+              aria-label={
+                isCol ? t('waterfall.expand') : t('waterfall.collapse')
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle(span.span_id);
+              }}
+              className="shrink-0 text-muted-foreground hover:text-foreground"
+            >
+              {isCol ? (
+                <ChevronRight className="size-3" />
+              ) : (
+                <ChevronDown className="size-3" />
+              )}
+            </button>
+          ) : (
+            <span className="inline-block size-3 shrink-0" />
+          )}
+          <span
+            className={cn(
+              'shrink-0 rounded px-1 py-px text-[10px] font-medium text-white',
+              opColor(span.op),
+            )}
+          >
+            {span.op || t('waterfall.spanFallback')}
+          </span>
+          <span className="truncate text-muted-foreground">
+            {span.description || '—'}
+          </span>
+          {failed && (
+            <span className="shrink-0 rounded bg-destructive/15 px-1 text-[10px] text-destructive">
+              {span.status}
+            </span>
+          )}
+        </div>
+        <div className="relative h-4 flex-1">
+          <div
+            className={cn('absolute inset-y-0 rounded-sm', opColor(span.op))}
+            style={{ left: `${offsetPct}%`, width: `${widthPct}%` }}
+          />
+        </div>
+        <span className="w-16 text-right tabular-nums text-muted-foreground">
+          {formatDuration(dur)}
+        </span>
+      </div>
+
+      {isSelected && <SpanDetail span={span} dur={dur} selfMs={selfMs} />}
     </div>
   );
 }

--- a/apps/webview-ui/src/features/transaction/ui/components/span-waterfall.tsx
+++ b/apps/webview-ui/src/features/transaction/ui/components/span-waterfall.tsx
@@ -302,10 +302,15 @@ function SpanWaterfallRow({
   const select = () => onSelect(isSelected ? null : (span.span_id ?? null));
 
   const selectKey = (e: KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      select();
-    }
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    // A key pressed inside the row's own collapse button belongs to that
+    // button. It stops click propagation but not keydown, and this handler
+    // calls `preventDefault`, which is what dispatches a native button's
+    // click: without this guard, Enter on the chevron selected the row and
+    // never expanded it.
+    if (e.target !== e.currentTarget) return;
+    e.preventDefault();
+    select();
   };
 
   return (

--- a/apps/webview-ui/src/shared/lib/waterfall-geometry.test.ts
+++ b/apps/webview-ui/src/shared/lib/waterfall-geometry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { barGeometry } from './waterfall-geometry';
+
+describe('barGeometry', () => {
+  it('places a bar at its share of the window', () => {
+    expect(barGeometry(150, 50, 100, 200)).toEqual({
+      offsetPct: 25,
+      widthPct: 25,
+    });
+  });
+
+  it('fills the window for a span that covers all of it', () => {
+    expect(barGeometry(100, 200, 100, 200)).toEqual({
+      offsetPct: 0,
+      widthPct: 100,
+    });
+  });
+
+  it('keeps a span far shorter than the window visible', () => {
+    // 0.05% of the window, which would round to nothing on screen. It may be
+    // the span that threw, so it gets the floor instead.
+    expect(barGeometry(100, 0.1, 100, 200).widthPct).toBe(0.5);
+  });
+
+  it('never runs a bar past the right edge', () => {
+    // Starts at 45% of the window and claims 75% of it: a span still running
+    // when the trace was cut. The overhang is clipped, not wrapped.
+    expect(barGeometry(190, 150, 100, 200)).toEqual({
+      offsetPct: 45,
+      widthPct: 55,
+    });
+  });
+
+  it('draws nothing for a span with no duration', () => {
+    expect(barGeometry(150, null, 100, 200)).toEqual({
+      offsetPct: 25,
+      widthPct: 0,
+    });
+  });
+
+  it('sits at the left edge when the span has no start', () => {
+    expect(barGeometry(null, 50, 100, 200)).toEqual({
+      offsetPct: 0,
+      widthPct: 25,
+    });
+  });
+
+  it('reads undefined the same as null: an absent field is an absent value', () => {
+    expect(barGeometry(undefined, undefined, 100, 200)).toEqual({
+      offsetPct: 0,
+      widthPct: 0,
+    });
+  });
+
+  it('draws nothing at all in a window of zero width', () => {
+    // Every span in a trace that started and ended in the same instant.
+    expect(barGeometry(100, 50, 100, 0)).toEqual({
+      offsetPct: 0,
+      widthPct: 0,
+    });
+  });
+});

--- a/apps/webview-ui/src/shared/lib/waterfall-geometry.test.ts
+++ b/apps/webview-ui/src/shared/lib/waterfall-geometry.test.ts
@@ -52,6 +52,30 @@ describe('barGeometry', () => {
     });
   });
 
+  /**
+   * Skewed data, not a drawing problem: an SDK whose clock ran backwards
+   * between the start and the end it reported. It used to produce a negative
+   * width, which is not a bar at all.
+   */
+  it('draws nothing for a span that starts after the window ends', () => {
+    expect(barGeometry(350, 10, 100, 200)).toEqual({
+      offsetPct: 100,
+      widthPct: 0,
+    });
+  });
+
+  it('never returns a negative width', () => {
+    for (const startAt of [201, 300, 1000]) {
+      expect(barGeometry(startAt, 10, 0, 200).widthPct).toBeGreaterThanOrEqual(
+        0,
+      );
+    }
+  });
+
+  it('pins a span that starts before the window to the left edge', () => {
+    expect(barGeometry(50, 50, 100, 200).offsetPct).toBe(0);
+  });
+
   it('draws nothing at all in a window of zero width', () => {
     // Every span in a trace that started and ended in the same instant.
     expect(barGeometry(100, 50, 100, 0)).toEqual({

--- a/apps/webview-ui/src/shared/lib/waterfall-geometry.ts
+++ b/apps/webview-ui/src/shared/lib/waterfall-geometry.ts
@@ -30,13 +30,21 @@ export function barGeometry(
 ): BarGeometry {
   if (windowSize <= 0) return { offsetPct: 0, widthPct: 0 };
 
-  const offsetPct =
+  const rawOffsetPct =
     startAt == null ? 0 : ((startAt - windowStart) / windowSize) * 100;
 
-  const widthPct =
+  const rawWidthPct =
     duration == null
       ? 0
       : Math.max(MIN_VISIBLE_PCT, (duration / windowSize) * 100);
 
-  return { offsetPct, widthPct: Math.min(widthPct, 100 - offsetPct) };
+  // Both ends are clamped to the track, not just the right one. A span that
+  // starts after the window ends is not a drawing problem, it is skewed data
+  // -- an SDK whose clock ran backwards between the start and the end it
+  // reported -- and without this it produced a negative width, which is not a
+  // bar at all.
+  const offsetPct = Math.min(100, Math.max(0, rawOffsetPct));
+  const widthPct = Math.max(0, Math.min(rawWidthPct, 100 - offsetPct));
+
+  return { offsetPct, widthPct };
 }

--- a/apps/webview-ui/src/shared/lib/waterfall-geometry.ts
+++ b/apps/webview-ui/src/shared/lib/waterfall-geometry.ts
@@ -1,0 +1,42 @@
+/** Where one span's bar sits on the shared clock, as CSS percentages. */
+export interface BarGeometry {
+  /** Distance from the left edge of the track. */
+  offsetPct: number;
+  /** Width of the bar, already clipped to the track's right edge. */
+  widthPct: number;
+}
+
+/** Below this a bar rounds to nothing on screen. */
+const MIN_VISIBLE_PCT = 0.5;
+
+/**
+ * One span's bar, placed against the window every row in a waterfall shares.
+ *
+ * All four arguments are in the same unit, whichever the caller keeps its
+ * clock in: the agent trace counts milliseconds, the transaction waterfall
+ * counts seconds, and this does not need to know which.
+ *
+ * Two floors carry the whole reason it exists. A 2 ms span inside a 600 ms
+ * trace is 0.3% wide and would round away, so it gets a visible minimum: it
+ * may be the one that threw. And a bar starting at 90% that claims 50% is
+ * clipped rather than allowed to overhang, because the track is the trace and
+ * nothing in the trace happened after it ended.
+ */
+export function barGeometry(
+  startAt: number | null | undefined,
+  duration: number | null | undefined,
+  windowStart: number,
+  windowSize: number,
+): BarGeometry {
+  if (windowSize <= 0) return { offsetPct: 0, widthPct: 0 };
+
+  const offsetPct =
+    startAt == null ? 0 : ((startAt - windowStart) / windowSize) * 100;
+
+  const widthPct =
+    duration == null
+      ? 0
+      : Math.max(MIN_VISIBLE_PCT, (duration / windowSize) * 100);
+
+  return { offsetPct, widthPct: Math.min(widthPct, 100 - offsetPct) };
+}

--- a/apps/webview-ui/src/shared/ui/components/command-bar/dialog/command-bar-dialog.tsx
+++ b/apps/webview-ui/src/shared/ui/components/command-bar/dialog/command-bar-dialog.tsx
@@ -133,6 +133,42 @@ export function CommandBarDialog({
     }
   };
 
+  /**
+   * Keys while the page column holds the selection.
+   *
+   * cmdk listens on its own root above this input, so anything claimed here
+   * has to stop bubbling or the list would move as well.
+   */
+  const handlePanelKey = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    current: number,
+    projectId: number,
+  ) => {
+    const step =
+      event.key === 'ArrowDown' ? 1 : event.key === 'ArrowUp' ? -1 : 0;
+
+    if (step !== 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      movePanel(
+        (current + step + ALL_PROJECT_PAGES.length) % ALL_PROJECT_PAGES.length,
+      );
+      return;
+    }
+
+    if (event.key === 'Tab' && !event.shiftKey) {
+      event.preventDefault();
+      togglePanel();
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      go(`/projects/${projectId}${ALL_PROJECT_PAGES[current].segment}`);
+    }
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     // `isMobile` as well as the selection: below `md` there is no column to
     // enter, and claiming Tab there would strand `panelIndexRef` non-null and
@@ -143,31 +179,10 @@ export function CommandBarDialog({
     // DOM focus reaches the column one render after `panelIndex` is set, so a
     // quick second keystroke still arrives here. Routing by intent rather than
     // by where focus happens to sit means entering the column never eats the
-    // key that follows it. cmdk listens on its own root above this input, so
-    // these have to stop bubbling or the list would move as well.
+    // key that follows it.
     const current = panelIndexRef.current;
-
     if (current !== null) {
-      const step =
-        event.key === 'ArrowDown' ? 1 : event.key === 'ArrowUp' ? -1 : 0;
-
-      if (step !== 0) {
-        event.preventDefault();
-        event.stopPropagation();
-        movePanel(
-          (current + step + ALL_PROJECT_PAGES.length) %
-            ALL_PROJECT_PAGES.length,
-        );
-      } else if (event.key === 'Tab' && !event.shiftKey) {
-        event.preventDefault();
-        togglePanel();
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        event.stopPropagation();
-        go(
-          `/projects/${selectedProject.id}${ALL_PROJECT_PAGES[current].segment}`,
-        );
-      }
+      handlePanelKey(event, current, selectedProject.id);
       return;
     }
 

--- a/apps/webview-ui/src/shared/ui/components/data-table/data-table.tsx
+++ b/apps/webview-ui/src/shared/ui/components/data-table/data-table.tsx
@@ -274,87 +274,118 @@ export function DataTable<TData extends RowData>({
         </TableHeader>
 
         <TableBody>
-          {rows.map((row) => {
-            const isExpanded = row.getIsExpanded();
-            const detail = isExpanded ? renderDetail?.(row) : null;
-
-            return (
-              <Fragment key={row.id}>
-                <TableRow
-                  data-state={row.getIsSelected() ? 'selected' : undefined}
-                  aria-expanded={renderDetail ? isExpanded : undefined}
-                  onClick={onRowClick ? () => onRowClick(row) : undefined}
-                  // The row is the control, so the row is the tab stop: this is
-                  // what the chevron in `expandColumn` is decorative *on the
-                  // basis of*. Without it `aria-expanded` announces a
-                  // disclosure that nothing can operate.
-                  tabIndex={onRowClick ? 0 : undefined}
-                  onKeyDown={
-                    onRowClick
-                      ? (event) => {
-                          if (event.key !== 'Enter' && event.key !== ' ')
-                            return;
-                          // A key pressed inside a cell's own control -- a
-                          // checkbox, a link -- belongs to that control.
-                          if (event.target !== event.currentTarget) return;
-                          // Or Space scrolls the page out from under the row it
-                          // just expanded.
-                          event.preventDefault();
-                          onRowClick(row);
-                        }
-                      : undefined
-                  }
-                  className={cn(
-                    onRowClick &&
-                      'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
-                    isExpanded && 'bg-muted/40 hover:bg-muted/40',
-                    getRowClassName?.(row),
-                  )}
-                >
-                  {row.getAllCells().map((cell) => {
-                    const meta = cell.column.columnDef.meta;
-                    return (
-                      <TableCell
-                        key={cell.id}
-                        style={{ width: widthOf(cell.column.id) }}
-                        className={cn(
-                          // `max-w-0` is what lets `truncate` inside a cell
-                          // measure against the column instead of the content,
-                          // which is the difference between a growing column
-                          // that ellipsises and one that forces a scrollbar.
-                          'max-w-0',
-                          spacing.cell,
-                          meta?.align === 'end' && 'text-right',
-                          meta?.hideBelow && HIDE_BELOW_CLASS[meta.hideBelow],
-                          meta?.className,
-                        )}
-                      >
-                        <table.FlexRender cell={cell} />
-                      </TableCell>
-                    );
-                  })}
-                  {fillerWidth > 0 && <td />}
-                </TableRow>
-
-                {detail && (
-                  <TableRow className="hover:bg-transparent">
-                    <TableCell
-                      colSpan={
-                        row.getAllCells().length + (fillerWidth > 0 ? 1 : 0)
-                      }
-                      className="bg-muted/20 p-0"
-                    >
-                      {detail}
-                    </TableCell>
-                  </TableRow>
-                )}
-              </Fragment>
-            );
-          })}
+          {rows.map((row) => (
+            <DataTableRow
+              key={row.id}
+              row={row}
+              table={table}
+              spacing={spacing}
+              fillerWidth={fillerWidth}
+              onRowClick={onRowClick}
+              getRowClassName={getRowClassName}
+              renderDetail={renderDetail}
+            />
+          ))}
         </TableBody>
       </Table>
 
       {rows.length === 0 && empty}
     </div>
+  );
+}
+
+interface DataTableRowProps<TData extends RowData> {
+  row: Row<DataTableFeatures, TData>;
+  /** Held only for `FlexRender`, which is a method on the instance. */
+  table: DataTableInstance<TData>;
+  spacing: (typeof DENSITY)[keyof typeof DENSITY];
+  /** Width of the trailing filler cell, or 0 when the columns fill the table. */
+  fillerWidth: number;
+  onRowClick?: (row: Row<DataTableFeatures, TData>) => void;
+  getRowClassName?: (row: Row<DataTableFeatures, TData>) => string | undefined;
+  renderDetail?: (row: Row<DataTableFeatures, TData>) => ReactNode;
+}
+
+/** One row, plus the full-width detail row underneath it when expanded. */
+function DataTableRow<TData extends RowData>({
+  row,
+  table,
+  spacing,
+  fillerWidth,
+  onRowClick,
+  getRowClassName,
+  renderDetail,
+}: DataTableRowProps<TData>) {
+  const isExpanded = row.getIsExpanded();
+  const detail = isExpanded ? renderDetail?.(row) : null;
+
+  const activate = onRowClick ? () => onRowClick(row) : undefined;
+
+  const onKeyDown = onRowClick
+    ? (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        // A key pressed inside a cell's own control -- a checkbox, a link --
+        // belongs to that control.
+        if (event.target !== event.currentTarget) return;
+        // Or Space scrolls the page out from under the row it just expanded.
+        event.preventDefault();
+        onRowClick(row);
+      }
+    : undefined;
+
+  return (
+    <Fragment>
+      <TableRow
+        data-state={row.getIsSelected() ? 'selected' : undefined}
+        aria-expanded={renderDetail ? isExpanded : undefined}
+        onClick={activate}
+        // The row is the control, so the row is the tab stop: this is what the
+        // chevron in `expandColumn` is decorative *on the basis of*. Without it
+        // `aria-expanded` announces a disclosure that nothing can operate.
+        tabIndex={onRowClick ? 0 : undefined}
+        onKeyDown={onKeyDown}
+        className={cn(
+          onRowClick &&
+            'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+          isExpanded && 'bg-muted/40 hover:bg-muted/40',
+          getRowClassName?.(row),
+        )}
+      >
+        {row.getAllCells().map((cell) => {
+          const meta = cell.column.columnDef.meta;
+          return (
+            <TableCell
+              key={cell.id}
+              style={{ width: widthOf(cell.column.id) }}
+              className={cn(
+                // `max-w-0` is what lets `truncate` inside a cell measure
+                // against the column instead of the content, which is the
+                // difference between a growing column that ellipsises and one
+                // that forces a scrollbar.
+                'max-w-0',
+                spacing.cell,
+                meta?.align === 'end' && 'text-right',
+                meta?.hideBelow && HIDE_BELOW_CLASS[meta.hideBelow],
+                meta?.className,
+              )}
+            >
+              <table.FlexRender cell={cell} />
+            </TableCell>
+          );
+        })}
+        {fillerWidth > 0 && <td />}
+      </TableRow>
+
+      {detail && (
+        <TableRow className="hover:bg-transparent">
+          <TableCell
+            colSpan={row.getAllCells().length + (fillerWidth > 0 ? 1 : 0)}
+            className="bg-muted/20 p-0"
+          >
+            {detail}
+          </TableCell>
+        </TableRow>
+      )}
+    </Fragment>
   );
 }

--- a/apps/webview-ui/vitest.config.mts
+++ b/apps/webview-ui/vitest.config.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -19,6 +20,19 @@ import { defineConfig } from 'vitest/config';
  * arrive in the commit that needs it.
  */
 export default defineConfig({
+  /**
+   * The one thing Next resolves for us that this config has to resolve itself.
+   *
+   * Type-only `@/` imports vanish at compile time, so a module using nothing
+   * but those ran here without an alias. The first unit test whose subject
+   * imports a real *value* through `@/` fails to resolve instead, which reads
+   * as a missing package rather than as missing config.
+   */
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     /**
      * Sequential files, one shared module registry, and it is a **20x

--- a/biome.json
+++ b/biome.json
@@ -95,7 +95,8 @@
         "noStaticOnlyClass": "off",
         "noBannedTypes": "off",
         "noForEach": "off",
-        "useLiteralKeys": "off"
+        "useLiteralKeys": "off",
+        "noExcessiveCognitiveComplexity": "error"
       },
       "a11y": {
         "useButtonType": "off",

--- a/packages/ui/src/components/data-table/column-header.tsx
+++ b/packages/ui/src/components/data-table/column-header.tsx
@@ -2,7 +2,11 @@ import type { Column, Header, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import { type ReactNode, useState } from 'react';
 import { focusRingInset } from '../../lib/focus';
-import { chevronFlip, interactiveTransition } from '../../lib/motion';
+import {
+  chevronFlip,
+  interactiveTransition,
+  pressScaleTrigger,
+} from '../../lib/motion';
 import { tv } from '../../lib/tv';
 import {
   ChevronDownIcon,
@@ -41,6 +45,10 @@ const columnHeader = tv({
       'font-mono text-column text-fg-meta uppercase',
       'select-none',
       interactiveTransition,
+      // Base UI swallows `:active` on anything that opens a popup: it opens on
+      // pointer-down and hands capture to the panel. Without this the header
+      // gives no feedback at all until the panel appears.
+      pressScaleTrigger,
       'hover:text-fg-subtle',
       'data-popup-open:text-fg-subtle',
       focusRingInset,

--- a/packages/ui/src/components/data-table/column-header.tsx
+++ b/packages/ui/src/components/data-table/column-header.tsx
@@ -1,6 +1,6 @@
-import type { Header, RowData } from '@tanstack/react-table';
+import type { Column, Header, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { focusRingInset } from '../../lib/focus';
 import { chevronFlip, interactiveTransition } from '../../lib/motion';
 import { tv } from '../../lib/tv';
@@ -11,7 +11,7 @@ import {
   ResolveIcon,
 } from '../icon/icon-catalog';
 import { Popover } from '../popover/popover';
-import type { DataTableFeatures } from './features';
+import type { ColumnFilterSpec, DataTableFeatures } from './features';
 import {
   OptionsFilterPanel,
   RangeFilterPanel,
@@ -102,10 +102,13 @@ export function DataTableColumnHeader<TData extends RowData>({
   const canHide = column.getCanHide();
   const filterSpec = meta?.filter;
   const [open, setOpen] = useState(false);
+  const close = () => setOpen(false);
 
   const title = flexRender(column.columnDef.header, header.getContext());
   const sorted = column.getIsSorted();
   const filtered = column.getIsFiltered();
+
+  const hasActions = filtered || canHide;
 
   if (!canSort && !filterSpec && !canHide) {
     return (
@@ -118,8 +121,6 @@ export function DataTableColumnHeader<TData extends RowData>({
     );
   }
 
-  const wording = sortWording(header);
-
   return (
     <Popover
       title={typeof title === 'string' ? title : (meta?.label ?? '')}
@@ -127,6 +128,10 @@ export function DataTableColumnHeader<TData extends RowData>({
       popupClassName="w-60"
       open={open}
       onOpenChange={setOpen}
+      /* Stays inline: `Popover` hands this to Base UI's `render` prop, which
+         merges the open handler, the ref and `data-popup-open` into whatever
+         element it is given. A component here would receive all of that as
+         props it does not forward, leaving a button that never opens. */
       trigger={
         <button
           type="button"
@@ -134,112 +139,184 @@ export function DataTableColumnHeader<TData extends RowData>({
           data-align={meta?.align}
           className={styles.trigger()}
         >
-          <span className={styles.label()}>{title}</span>
-          {sorted ? (
-            <span aria-hidden="true" className={styles.arrow()}>
-              {sorted === 'desc' ? '↓' : '↑'}
-            </span>
-          ) : null}
-          {filtered ? (
-            <FilterIcon
-              size="sm"
-              aria-hidden="true"
-              className={styles.funnel()}
-            />
-          ) : null}
-          <ChevronDownIcon
-            size="sm"
-            aria-hidden="true"
-            className={styles.chevron()}
-          />
+          <TriggerContent title={title} sorted={sorted} filtered={filtered} />
         </button>
       }
     >
       {canSort ? (
-        <div className={styles.section()}>
-          {(['asc', 'desc'] as const).map((direction) => (
-            <button
-              key={direction}
-              type="button"
-              aria-pressed={sorted === direction}
-              className={styles.item()}
-              onClick={() => {
-                // Choosing the standing sort again clears it: the header is a
-                // question, and asking the same question twice withdraws it.
-                if (sorted === direction) column.clearSorting();
-                else column.toggleSorting(direction === 'desc');
-                setOpen(false);
-              }}
-            >
-              <span aria-hidden="true" className="w-3 shrink-0 text-fg-ghost">
-                {direction === 'desc' ? '↓' : '↑'}
-              </span>
-              <span className="min-w-0 flex-1 truncate text-start">
-                {wording[direction]}
-              </span>
-              {sorted === direction ? (
-                <ResolveIcon
-                  size="sm"
-                  aria-hidden="true"
-                  className={styles.check()}
-                />
-              ) : null}
-            </button>
-          ))}
-        </div>
+        <SortSection header={header} sorted={sorted} onDone={close} />
       ) : null}
 
-      {canSort && filterSpec ? (
-        <div aria-hidden="true" className={styles.separator()} />
-      ) : null}
+      {canSort && filterSpec ? <Separator /> : null}
 
-      {filterSpec?.variant === 'options' ? (
-        <OptionsFilterPanel column={column} />
-      ) : null}
-      {filterSpec?.variant === 'text' ? (
-        <TextFilterPanel column={column} />
-      ) : null}
-      {filterSpec?.variant === 'range' ? (
-        <RangeFilterPanel column={column} />
-      ) : null}
+      <FilterSection column={column} spec={filterSpec} />
 
-      {(filtered || canHide) && (canSort || filterSpec) ? (
-        <div aria-hidden="true" className={styles.separator()} />
-      ) : null}
+      {hasActions && (canSort || filterSpec) ? <Separator /> : null}
 
-      {filtered || canHide ? (
-        <div className={styles.section()}>
-          {filtered ? (
-            <button
-              type="button"
-              className={styles.item()}
-              onClick={() => column.setFilterValue(undefined)}
-            >
-              <CloseIcon
-                size="sm"
-                aria-hidden="true"
-                className="shrink-0 text-fg-ghost"
-              />
-              <span className="min-w-0 flex-1 truncate text-start">
-                Clear filter
-              </span>
-            </button>
-          ) : null}
-          {canHide ? (
-            <button
-              type="button"
-              className={styles.item()}
-              onClick={() => column.toggleVisibility(false)}
-            >
-              <span className="w-3 shrink-0" aria-hidden="true" />
-              <span className="min-w-0 flex-1 truncate text-start">
-                Hide column
-              </span>
-            </button>
-          ) : null}
-        </div>
+      {hasActions ? (
+        <ActionsSection
+          column={column}
+          canClearFilter={filtered}
+          canHide={canHide}
+        />
       ) : null}
     </Popover>
+  );
+}
+
+const Separator = () => (
+  <div aria-hidden="true" className={styles.separator()} />
+);
+
+/**
+ * What the header says about itself: its label, its sort, its filter.
+ *
+ * Only the children -- the `<button>` around them stays inline in the trigger,
+ * where Base UI's `render` prop needs a real element to merge into.
+ */
+function TriggerContent({
+  title,
+  sorted,
+  filtered,
+}: {
+  title: ReactNode;
+  sorted: false | 'asc' | 'desc';
+  filtered: boolean;
+}) {
+  return (
+    <>
+      <span className={styles.label()}>{title}</span>
+      {sorted ? (
+        <span aria-hidden="true" className={styles.arrow()}>
+          {sorted === 'desc' ? '↓' : '↑'}
+        </span>
+      ) : null}
+      {filtered ? (
+        <FilterIcon size="sm" aria-hidden="true" className={styles.funnel()} />
+      ) : null}
+      <ChevronDownIcon
+        size="sm"
+        aria-hidden="true"
+        className={styles.chevron()}
+      />
+    </>
+  );
+}
+
+/** The two directions, worded for what the column actually holds. */
+function SortSection<TData extends RowData>({
+  header,
+  sorted,
+  onDone,
+}: {
+  header: Header<DataTableFeatures, TData, unknown>;
+  sorted: false | 'asc' | 'desc';
+  onDone: () => void;
+}) {
+  const { column } = header;
+  const wording = sortWording(header);
+
+  return (
+    <div className={styles.section()}>
+      {(['asc', 'desc'] as const).map((direction) => (
+        <button
+          key={direction}
+          type="button"
+          aria-pressed={sorted === direction}
+          className={styles.item()}
+          onClick={() => {
+            // Choosing the standing sort again clears it: the header is a
+            // question, and asking the same question twice withdraws it.
+            if (sorted === direction) column.clearSorting();
+            else column.toggleSorting(direction === 'desc');
+            onDone();
+          }}
+        >
+          <span aria-hidden="true" className="w-3 shrink-0 text-fg-ghost">
+            {direction === 'desc' ? '↓' : '↑'}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-start">
+            {wording[direction]}
+          </span>
+          {sorted === direction ? (
+            <ResolveIcon
+              size="sm"
+              aria-hidden="true"
+              className={styles.check()}
+            />
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The panel for a column's filter variant.
+ *
+ * Keyed rather than chained so a variant added to `ColumnFilterSpec` is a type
+ * error here until it has a panel, instead of a column whose filter silently
+ * renders nothing.
+ */
+const FILTER_PANELS = {
+  options: OptionsFilterPanel,
+  text: TextFilterPanel,
+  range: RangeFilterPanel,
+} satisfies Record<ColumnFilterSpec['variant'], unknown>;
+
+function FilterSection<TData extends RowData>({
+  column,
+  spec,
+}: {
+  column: Column<DataTableFeatures, TData, unknown>;
+  spec: ColumnFilterSpec | undefined;
+}) {
+  if (!spec) return null;
+  const Panel = FILTER_PANELS[spec.variant];
+  return <Panel column={column} />;
+}
+
+/** What can be undone from here: the filter, and the column itself. */
+function ActionsSection<TData extends RowData>({
+  column,
+  canClearFilter,
+  canHide,
+}: {
+  column: Column<DataTableFeatures, TData, unknown>;
+  canClearFilter: boolean;
+  canHide: boolean;
+}) {
+  return (
+    <div className={styles.section()}>
+      {canClearFilter ? (
+        <button
+          type="button"
+          className={styles.item()}
+          onClick={() => column.setFilterValue(undefined)}
+        >
+          <CloseIcon
+            size="sm"
+            aria-hidden="true"
+            className="shrink-0 text-fg-ghost"
+          />
+          <span className="min-w-0 flex-1 truncate text-start">
+            Clear filter
+          </span>
+        </button>
+      ) : null}
+      {canHide ? (
+        <button
+          type="button"
+          className={styles.item()}
+          onClick={() => column.toggleVisibility(false)}
+        >
+          <span className="w-3 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate text-start">
+            Hide column
+          </span>
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/ui/src/components/data-table/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table/data-table.stories.tsx
@@ -102,67 +102,84 @@ const ISSUES: Issue[] = Array.from({ length: 60 }, (_, index) => {
   };
 });
 
-/** What the Rust server will do, done to the fixture: the story's backend. */
-function fakeServer(query: DataTableQuery): { rows: Issue[]; total: number } {
-  let rows = ISSUES.filter((issue) => {
-    for (const filter of query.filters) {
-      if (filter.id === 'level') {
-        if (!(filter.value as string[]).includes(issue.level)) return false;
-      }
-      if (filter.id === 'events') {
-        const [min, max] = filter.value as [number | null, number | null];
-        if (min !== null && issue.events < min) return false;
-        if (max !== null && issue.events > max) return false;
-      }
-      if (filter.id === 'culprit') {
-        const needle = (filter.value as string).toLowerCase();
-        if (!issue.culprit.toLowerCase().includes(needle)) return false;
-      }
-      if (filter.id === 'title') {
-        const needle = (filter.value as string).toLowerCase();
-        if (!issue.title.toLowerCase().includes(needle)) return false;
-      }
-      if (filter.id === 'users') {
-        const [min, max] = filter.value as [number | null, number | null];
-        if (min !== null && issue.users < min) return false;
-        if (max !== null && issue.users > max) return false;
-      }
-      if (filter.id === 'seen') {
-        const cutoff = Number((filter.value as string[])[0]);
-        if (issue.seenMinutesAgo > cutoff) return false;
-      }
-    }
-    if (query.search) {
-      const needle = query.search.toLowerCase();
-      if (!`${issue.title} ${issue.culprit}`.toLowerCase().includes(needle)) {
-        return false;
-      }
-    }
-    return true;
-  });
+const SEVERITY = { info: 0, warning: 1, error: 2, fatal: 3 } as const;
 
-  const SEVERITY = { info: 0, warning: 1, error: 2, fatal: 3 } as const;
+/** Whether `issue` passes one filter, keyed by the column the filter names. */
+const MATCHERS: Record<string, (issue: Issue, value: unknown) => boolean> = {
+  level: (issue, value) => (value as string[]).includes(issue.level),
+
+  events: (issue, value) => inRange(issue.events, value),
+  users: (issue, value) => inRange(issue.users, value),
+
+  culprit: (issue, value) => contains(issue.culprit, value as string),
+  title: (issue, value) => contains(issue.title, value as string),
+
+  // The one filter whose option value is not what it compares against: the
+  // rows carry an age and the options carry a cutoff.
+  seen: (issue, value) =>
+    issue.seenMinutesAgo <= Number((value as string[])[0]),
+};
+
+const inRange = (n: number, value: unknown): boolean => {
+  const [min, max] = value as [number | null, number | null];
+  return (min === null || n >= min) && (max === null || n <= max);
+};
+
+const contains = (haystack: string, needle: string): boolean =>
+  haystack.toLowerCase().includes(needle.toLowerCase());
+
+/** A filter naming a column with no matcher is ignored, not fatal. */
+function matchesFilters(issue: Issue, query: DataTableQuery): boolean {
+  return query.filters.every(
+    (filter) => MATCHERS[filter.id]?.(issue, filter.value) ?? true,
+  );
+}
+
+/** Free text searches the two columns a reader would expect it to. */
+function matchesSearch(issue: Issue, search: string): boolean {
+  if (!search) return true;
+  return contains(`${issue.title} ${issue.culprit}`, search);
+}
+
+/** Column ids are the URL's names, and two of them are not field names. */
+function sortValue(issue: Issue, id: string): number | string {
+  if (id === 'level') return SEVERITY[issue.level];
+  if (id === 'seen') return issue.seenMinutesAgo;
+  return issue[id as keyof Issue] as number | string;
+}
+
+function sortRows(rows: Issue[], query: DataTableQuery): Issue[] {
   const sort = query.sorting[0];
-  if (sort) {
-    // Column ids are the URL's names; two of them are not field names.
-    const key = (
-      sort.id === 'seen' ? 'seenMinutesAgo' : sort.id
-    ) as keyof Issue;
-    rows = [...rows].sort((a, b) => {
-      const left = key === 'level' ? SEVERITY[a.level] : a[key];
-      const right = key === 'level' ? SEVERITY[b.level] : b[key];
-      const order =
-        typeof left === 'number' && typeof right === 'number'
-          ? left - right
-          : String(left).localeCompare(String(right));
-      return sort.desc ? -order : order;
-    });
-  }
+  if (!sort) return rows;
+
+  return [...rows].sort((a, b) => {
+    const left = sortValue(a, sort.id);
+    const right = sortValue(b, sort.id);
+    const order =
+      typeof left === 'number' && typeof right === 'number'
+        ? left - right
+        : String(left).localeCompare(String(right));
+    return sort.desc ? -order : order;
+  });
+}
+
+/**
+ * What the Rust server will do, done to the fixture: the story's backend.
+ *
+ * Worth reading as documentation rather than as scaffolding -- this is the
+ * filter, sort and page behaviour the real endpoint is expected to match.
+ */
+function fakeServer(query: DataTableQuery): { rows: Issue[]; total: number } {
+  const matched = ISSUES.filter(
+    (issue) =>
+      matchesFilters(issue, query) && matchesSearch(issue, query.search),
+  );
+  const sorted = sortRows(matched, query);
 
   const { pageIndex, pageSize } = query.pagination;
   return {
-    rows: rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
-    total: rows.length,
+    rows: sorted.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+    total: matched.length,
   };
 }
 

--- a/packages/ui/src/components/data-table/data-table.tsx
+++ b/packages/ui/src/components/data-table/data-table.tsx
@@ -1,4 +1,4 @@
-import type { Cell, Row, RowData } from '@tanstack/react-table';
+import type { Cell, Header, Row, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import type { MouseEvent, ReactNode } from 'react';
 import { interactiveTransition, swapAnimation } from '../../lib/motion';
@@ -204,40 +204,9 @@ export function DataTable<TData extends RowData>({
                     </th>
                   </>
                 ) : (
-                  headerGroup.headers.map((header) => {
-                    const sorted = header.column.getIsSorted();
-                    return (
-                      <th
-                        key={header.id}
-                        scope="col"
-                        colSpan={header.colSpan}
-                        aria-sort={
-                          sorted === 'asc'
-                            ? 'ascending'
-                            : sorted === 'desc'
-                              ? 'descending'
-                              : undefined
-                        }
-                        className={styles.th()}
-                      >
-                        {header.isPlaceholder ? null : header.column.id ===
-                          'select' ? (
-                          <span className="flex items-center">
-                            {flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
-                            )}
-                          </span>
-                        ) : (
-                          /* Re-enters the same way the bulk strip arrived, so
-                             the swap reads as one exchange, not two events. */
-                          <div className={styles.headerSwap()}>
-                            <DataTableColumnHeader header={header} />
-                          </div>
-                        )}
-                      </th>
-                    );
-                  })
+                  headerGroup.headers.map((header) => (
+                    <HeaderCell key={header.id} header={header} />
+                  ))
                 )}
               </tr>
             ))}
@@ -334,3 +303,60 @@ export function DataTable<TData extends RowData>({
 }
 
 DataTable.displayName = 'DataTable';
+
+/**
+ * One column heading.
+ *
+ * `aria-sort` is on the `th` rather than on the button inside it because the
+ * sort state describes the column, and a screen reader reads it while moving
+ * between columns, not only when it lands on the control.
+ */
+function HeaderCell<TData extends RowData>({
+  header,
+}: {
+  header: Header<DataTableFeatures, TData, unknown>;
+}) {
+  const sorted = header.column.getIsSorted();
+  const ariaSort =
+    sorted === 'asc'
+      ? 'ascending'
+      : sorted === 'desc'
+        ? 'descending'
+        : undefined;
+
+  return (
+    <th
+      scope="col"
+      colSpan={header.colSpan}
+      aria-sort={ariaSort}
+      className={styles.th()}
+    >
+      <HeaderContent header={header} />
+    </th>
+  );
+}
+
+/** The heading itself: the select box renders bare, every other column swaps. */
+function HeaderContent<TData extends RowData>({
+  header,
+}: {
+  header: Header<DataTableFeatures, TData, unknown>;
+}) {
+  if (header.isPlaceholder) return null;
+
+  if (header.column.id === 'select') {
+    return (
+      <span className="flex items-center">
+        {flexRender(header.column.columnDef.header, header.getContext())}
+      </span>
+    );
+  }
+
+  return (
+    /* Re-enters the same way the bulk strip arrived, so the swap reads as one
+       exchange, not two events. */
+    <div className={styles.headerSwap()}>
+      <DataTableColumnHeader header={header} />
+    </div>
+  );
+}

--- a/packages/ui/src/components/data-table/query.test.ts
+++ b/packages/ui/src/components/data-table/query.test.ts
@@ -72,6 +72,28 @@ describe('parseFilterQuery', () => {
     expect(filters).toEqual([{ id: 'release', value: 'say "hi" now' }]);
   });
 
+  it('drops an option list that names no option', () => {
+    const { filters, search } = parseFilterQuery('level:,, timeout', variants);
+
+    expect(filters).toEqual([]);
+    expect(search).toBe('timeout');
+  });
+
+  /**
+   * Not symmetric with the case above, and deliberately so: a malformed option
+   * list can only have been an attempt at a filter, while `events:oops` is a
+   * plausible start of a pasted line and is worth keeping as prose.
+   */
+  it('keeps a malformed range as free text rather than dropping it', () => {
+    const { filters, search } = parseFilterQuery(
+      'events:oops timeout',
+      variants,
+    );
+
+    expect(filters).toEqual([]);
+    expect(search).toBe('events:oops timeout');
+  });
+
   it('merges a key written twice instead of duplicating it', () => {
     const { filters } = parseFilterQuery('level:error level:fatal', variants);
 

--- a/packages/ui/src/components/data-table/query.ts
+++ b/packages/ui/src/components/data-table/query.ts
@@ -110,12 +110,108 @@ function parseRange(raw: string): [number | null, number | null] | null {
   return [min, max];
 }
 
+/** A value that has to survive a round trip through the string is quoted. */
+function quoted(value: string): string {
+  return needsQuoting(value) ? quoteValue(value) : value;
+}
+
+/**
+ * What one token turned out to be.
+ *
+ * `drop` is the third answer the two obvious ones cannot express: a token that
+ * is neither a usable filter nor prose worth carrying. Naming it is what keeps
+ * the variants below able to disagree about which of the three a failed parse
+ * deserves, in one visible place rather than by omission.
+ */
+type ParsedValue =
+  | { kind: 'filter'; value: unknown }
+  | { kind: 'text' }
+  | { kind: 'drop' };
+
+/** A {@link ParsedValue} once the key it belongs to is known. */
+type ParsedToken =
+  | { kind: 'filter'; id: string; value: unknown }
+  | { kind: 'text' }
+  | { kind: 'drop' };
+
+/**
+ * How one variant crosses between the string and the filter state.
+ *
+ * Both directions live together because they are one format described twice,
+ * and when they sat in two `variant` chains in two functions they had already
+ * drifted: nothing made a value the formatter wrote parse back to itself.
+ */
+interface FilterCodec {
+  /** The state value for the text after the colon. */
+  parse: (raw: string) => ParsedValue;
+  /** The text after the colon for a state value, or `null` if it says nothing. */
+  format: (value: unknown) => string | null;
+}
+
+const optionsCodec: FilterCodec = {
+  parse: (raw) => {
+    const values = raw.split(',').filter(Boolean);
+    // `level:,,` names no option and is not prose either: the user reached for
+    // a filter and gave it nothing.
+    return values.length ? { kind: 'filter', value: values } : { kind: 'drop' };
+  },
+
+  format: (value) =>
+    Array.isArray(value) && value.length ? value.join(',') : null,
+};
+
+const rangeCodec: FilterCodec = {
+  parse: (raw) => {
+    const range = parseRange(raw);
+    // Unlike a malformed option list, `events:oops` may well be prose -- it is
+    // a plausible start of a pasted line -- so it is kept rather than dropped.
+    return range ? { kind: 'filter', value: range } : { kind: 'text' };
+  },
+
+  format: (value) => {
+    if (!Array.isArray(value)) return null;
+    const [min, max] = value as [number | null, number | null];
+    if (min === null && max === null) return null;
+    return `${min ?? ''}..${max ?? ''}`;
+  },
+};
+
+const textCodec: FilterCodec = {
+  parse: (raw) => ({ kind: 'filter', value: raw }),
+
+  format: (value) =>
+    typeof value === 'string' && value ? quoted(value) : null,
+};
+
+const CODECS: Record<ColumnFilterSpec['variant'], FilterCodec> = {
+  options: optionsCodec,
+  range: rangeCodec,
+  text: textCodec,
+};
+
+/** One token, resolved against the columns this table can actually filter. */
+function parseToken(token: string, variants: FilterVariants): ParsedToken {
+  const match = token.match(TOKEN);
+  const id = match?.[1];
+  const raw = match?.[2];
+  const variant = id ? variants[id] : undefined;
+
+  // A `key:` the table has no filterable column for stays free text rather
+  // than becoming a phantom filter: `error:` at the start of a pasted stack
+  // trace is prose, not a request.
+  if (id === undefined || raw === undefined || !variant)
+    return { kind: 'text' };
+
+  // A known key with nothing after the colon says nothing: `level:` is a
+  // question abandoned mid-sentence, not prose and not a filter.
+  if (raw === '') return { kind: 'drop' };
+
+  const parsed = CODECS[variant].parse(raw);
+  return parsed.kind === 'filter' ? { ...parsed, id } : parsed;
+}
+
 /**
  * Reads a query string into filters and free text.
- *
- * A `key:` the table has no filterable column for stays free text rather than
- * becoming a phantom filter: `error:` at the start of a pasted stack trace is
- * prose, not a request.
  */
 export function parseFilterQuery(
   input: string,
@@ -125,26 +221,11 @@ export function parseFilterQuery(
   const text: string[] = [];
 
   for (const token of tokenize(input)) {
-    const match = token.match(TOKEN);
-    const id = match?.[1];
-    const raw = match?.[2];
-    const variant = id ? variants[id] : undefined;
-    if (id === undefined || raw === undefined || !variant) {
-      text.push(token);
-      continue;
-    }
-    // A known key with nothing after the colon says nothing: `level:` is a
-    // question abandoned mid-sentence, not prose and not a filter.
-    if (raw === '') continue;
-    if (variant === 'options') {
-      const values = raw.split(',').filter(Boolean);
-      if (values.length) filters.push({ id, value: values });
-    } else if (variant === 'range') {
-      const range = parseRange(raw);
-      if (range) filters.push({ id, value: range });
-      else text.push(token);
-    } else {
-      filters.push({ id, value: raw });
+    const parsed = parseToken(token, variants);
+
+    if (parsed.kind === 'text') text.push(token);
+    else if (parsed.kind === 'filter') {
+      filters.push({ id: parsed.id, value: parsed.value });
     }
   }
 
@@ -181,19 +262,12 @@ export function formatFilterQuery(
 
   for (const { id, value } of filters) {
     const variant = variants[id];
-    if (variant === 'options' && Array.isArray(value) && value.length) {
-      tokens.push(`${id}:${value.join(',')}`);
-    } else if (variant === 'range' && Array.isArray(value)) {
-      const [min, max] = value as [number | null, number | null];
-      if (min !== null || max !== null) {
-        tokens.push(`${id}:${min ?? ''}..${max ?? ''}`);
-      }
-    } else if (variant === 'text' && typeof value === 'string' && value) {
-      tokens.push(`${id}:${needsQuoting(value) ? quoteValue(value) : value}`);
-    }
+    const formatted = variant ? CODECS[variant].format(value) : null;
+    if (formatted !== null) tokens.push(`${id}:${formatted}`);
   }
 
-  if (search) tokens.push(needsQuoting(search) ? quoteValue(search) : search);
+  if (search) tokens.push(quoted(search));
+
   return tokens.join(' ');
 }
 

--- a/packages/ui/src/components/query-bar/query-bar-parts.test.ts
+++ b/packages/ui/src/components/query-bar/query-bar-parts.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { DataTableColumnDef } from '../data-table/features';
-import { queryFieldsFromColumns, variantsFromFields } from './query-bar-parts';
+import {
+  detectPhase,
+  type QueryField,
+  queryFieldsFromColumns,
+  variantsFromFields,
+} from './query-bar-parts';
 
 interface Issue {
   title: string;
@@ -57,5 +62,61 @@ describe('variantsFromFields', () => {
       title: 'text',
       release: 'options',
     });
+  });
+});
+
+describe('detectPhase', () => {
+  const fields: QueryField[] = [
+    { key: 'level', label: 'Level', variant: 'options' },
+    { key: 'events', label: 'Events', variant: 'range' },
+  ];
+
+  it('completes a field name while nothing is in force', () => {
+    const phase = detectPhase('lev', fields, null);
+
+    expect(phase.activeField).toBeUndefined();
+    expect(phase.fieldNeedle).toBe('lev');
+    expect(phase.prefix).toBe('');
+  });
+
+  it('keeps what was already typed before the fragment', () => {
+    const phase = detectPhase('timeout lev', fields, null);
+
+    expect(phase.fieldNeedle).toBe('lev');
+    expect(phase.prefix).toBe('timeout ');
+  });
+
+  it('reads a typed key: token as the field in force', () => {
+    const phase = detectPhase('level:err', fields, null);
+
+    expect(phase.typedField?.key).toBe('level');
+    expect(phase.activeField?.key).toBe('level');
+    expect(phase.valueFragment).toBe('err');
+    // The whole token is replaced, `key:` included.
+    expect(phase.prefix).toBe('');
+  });
+
+  it('lets a picked field win over a typed token', () => {
+    const phase = detectPhase('level:err', fields, 'events');
+
+    expect(phase.pickedField?.key).toBe('events');
+    expect(phase.activeField?.key).toBe('events');
+    // A pick replaces only the fragment, so the token stays prose.
+    expect(phase.valueFragment).toBe('level:err');
+  });
+
+  it('offers no field name once a field is in force', () => {
+    expect(detectPhase('level:err', fields, null).fieldNeedle).toBe('');
+  });
+
+  it('ignores a key: token for a field the table does not have', () => {
+    const phase = detectPhase('nope:x', fields, null);
+
+    expect(phase.typedField).toBeUndefined();
+    expect(phase.fieldNeedle).toBe('nope:x');
+  });
+
+  it('treats an unknown picked key as no pick at all', () => {
+    expect(detectPhase('x', fields, 'gone').pickedField).toBeUndefined();
   });
 });

--- a/packages/ui/src/components/query-bar/query-bar-parts.ts
+++ b/packages/ui/src/components/query-bar/query-bar-parts.ts
@@ -70,3 +70,82 @@ export function queryFieldsFromColumns<TData extends RowData>(
 export function variantsFromFields(fields: QueryField[]): FilterVariants {
   return Object.fromEntries(fields.map((field) => [field.key, field.variant]));
 }
+
+/**
+ * What the bar is currently being asked, read off the draft alone.
+ *
+ * The bar has three phases and they are not exclusive to one another's
+ * syntax: no field yet (completing a field name), a field picked from the
+ * list (`pickedKey`, which never appears in the input), and a field typed as
+ * a `key:` token. This resolves all three into one answer so the hook and the
+ * suggestion list cannot disagree about which one is running.
+ */
+export interface QueryPhase {
+  /** The field named by a `key:` token under the caret, if any. */
+  typedField: QueryField | undefined;
+  /** The field taken from the list, whose values the popup is offering. */
+  pickedField: QueryField | undefined;
+  /** Whichever of the two is in force; a pick wins over a typed token. */
+  activeField: QueryField | undefined;
+  /** What is being typed as a value, once a field is in force. */
+  valueFragment: string;
+  /** What is being typed as a field name, while none is in force. */
+  fieldNeedle: string;
+  /** The part of the draft a completion keeps, verbatim. */
+  prefix: string;
+}
+
+export function detectPhase(
+  draft: string,
+  fields: QueryField[],
+  pickedKey: string | null,
+): QueryPhase {
+  const tokenMatch = draft.match(/(^|\s)([A-Za-z0-9_.-]+):(\S*)$/);
+  const typedField = tokenMatch
+    ? fields.find((field) => field.key === tokenMatch[2])
+    : undefined;
+  const pickedField = pickedKey
+    ? fields.find((field) => field.key === pickedKey)
+    : undefined;
+  const activeField = pickedField ?? typedField;
+
+  /*
+   * Only the word under the caret is being completed; whatever stands before
+   * it is already said and survives the completion. So `timeout lev` offers
+   * Level, and taking it keeps `timeout` -- the fragment is replaced, never
+   * appended to.
+   */
+  const fragmentMatch = draft.match(/(^|\s)(\S*)$/);
+  const fragment = fragmentMatch?.[2] ?? '';
+  const fragmentPrefix = draft.slice(
+    0,
+    (fragmentMatch?.index ?? 0) + (fragmentMatch?.[1]?.length ?? 0),
+  );
+
+  // With a picked field, whatever is being typed narrows its values. With a
+  // typed one, the value is the text after its colon.
+  const valueFragment = pickedField
+    ? fragment
+    : typedField
+      ? (tokenMatch?.[3] ?? '')
+      : '';
+
+  // A typed token is replaced whole, `key:` included; anything else replaces
+  // only the fragment.
+  const prefix =
+    !pickedField && typedField
+      ? draft.slice(
+          0,
+          (tokenMatch?.index ?? 0) + (tokenMatch?.[1]?.length ?? 0),
+        )
+      : fragmentPrefix;
+
+  return {
+    typedField,
+    pickedField,
+    activeField,
+    valueFragment,
+    fieldNeedle: activeField ? '' : fragment.toLowerCase(),
+    prefix,
+  };
+}

--- a/packages/ui/src/components/query-bar/use-query-bar.ts
+++ b/packages/ui/src/components/query-bar/use-query-bar.ts
@@ -9,7 +9,28 @@ import {
 } from 'react';
 import type { FilterOption } from '../data-table/features';
 import { formatFilterQuery, parseFilterQuery } from '../data-table/query';
-import { type QueryField, variantsFromFields } from './query-bar-parts';
+import {
+  detectPhase,
+  type QueryField,
+  variantsFromFields,
+} from './query-bar-parts';
+
+/**
+ * The values a field holds once one option is ticked.
+ *
+ * Ticking the standing choice of a single-choice field clears it rather than
+ * re-picking it: the same "asking twice withdraws the question" rule the
+ * column headers use for sort.
+ */
+function nextSelection(
+  selected: string[],
+  value: string,
+  multiple: boolean,
+): string[] {
+  const has = selected.includes(value);
+  if (!multiple) return has ? [] : [value];
+  return has ? selected.filter((v) => v !== value) : [...selected, value];
+}
 
 export type Suggestion =
   | { kind: 'field'; field: QueryField }
@@ -80,42 +101,8 @@ export function useQueryBar({
 
   /* --- Phase detection --------------------------------------------------- */
 
-  const tokenMatch = draft.match(/(^|\s)([A-Za-z0-9_.-]+):(\S*)$/);
-  const typedField = tokenMatch
-    ? fields.find((field) => field.key === tokenMatch[2])
-    : undefined;
-  const pickedField = pickedKey
-    ? fields.find((field) => field.key === pickedKey)
-    : undefined;
-  const activeField = pickedField ?? typedField;
-
-  /*
-   * Only the word under the caret is being completed; whatever stands before
-   * it is already said and survives the completion. So `timeout lev` offers
-   * Level, and taking it keeps `timeout` -- the fragment is replaced,
-   * never appended to.
-   */
-  const fragmentMatch = draft.match(/(^|\s)(\S*)$/);
-  const fragment = fragmentMatch?.[2] ?? '';
-  const fragmentPrefix = draft.slice(
-    0,
-    (fragmentMatch?.index ?? 0) + (fragmentMatch?.[1]?.length ?? 0),
-  );
-
-  // With a picked field, whatever is being typed narrows its values.
-  const valueFragment = pickedField
-    ? fragment
-    : typedField
-      ? (tokenMatch?.[3] ?? '')
-      : '';
-  const fieldNeedle = activeField ? '' : fragment.toLowerCase();
-  const prefix =
-    !pickedField && typedField
-      ? draft.slice(
-          0,
-          (tokenMatch?.index ?? 0) + (tokenMatch?.[1]?.length ?? 0),
-        )
-      : fragmentPrefix;
+  const { pickedField, activeField, valueFragment, fieldNeedle, prefix } =
+    detectPhase(draft, fields, pickedKey);
 
   const fieldOptions = activeField
     ? (activeField.options ?? loadedOptions[activeField.key])
@@ -213,16 +200,12 @@ export function useQueryBar({
   }
 
   function toggleValue(field: QueryField, option: FilterOption) {
-    const selected = selectedValues(field.key);
-    const has = selected.includes(option.value);
     const multiple = field.multiple ?? true;
-    const nextValues = multiple
-      ? has
-        ? selected.filter((value) => value !== option.value)
-        : [...selected, option.value]
-      : has
-        ? []
-        : [option.value];
+    const nextValues = nextSelection(
+      selectedValues(field.key),
+      option.value,
+      multiple,
+    );
 
     const rest = filters.filter((filter) => filter.id !== field.key);
     onChange({
@@ -291,70 +274,102 @@ export function useQueryBar({
 
   /* --- Keyboard ---------------------------------------------------------- */
 
+  /** Moves the highlight and brings the row into view. Opens the list first. */
+  function moveHighlight(delta: 1 | -1) {
+    if (!open) {
+      setOpen(true);
+      return;
+    }
+
+    const next =
+      (highlightIndex + delta + suggestions.length) %
+      Math.max(suggestions.length, 1);
+    setHighlighted(next);
+
+    // The list scrolls, the input keeps focus: the highlighted row has to be
+    // brought along by hand.
+    document
+      .getElementById(`${id}-option-${next}`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }
+
+  /** Enter takes the highlighted suggestion, or commits what is written. */
+  function commitOrApply() {
+    const current = suggestions[highlightIndex];
+    if (open && current) {
+      apply(current);
+      return;
+    }
+
+    commitDraft(draft);
+    setOpen(false);
+    setPickedKey(null);
+  }
+
+  /**
+   * Tab completes a field name and nothing else.
+   *
+   * On a value or the search row it falls through to the browser, because
+   * there Tab is the only way out of the bar.
+   */
+  function completeField(event: KeyboardEvent<HTMLInputElement>) {
+    const current = suggestions[highlightIndex];
+    if (current?.kind !== 'field') return;
+
+    event.preventDefault();
+    apply(current);
+  }
+
+  /** Escape closes the list; with the list already closed, it clears. */
+  function dismiss() {
+    if (open) {
+      setOpen(false);
+      setPickedKey(null);
+      return;
+    }
+    if (!draft) return;
+
+    // The popup is already closed, so this draft is exactly what is committed
+    // (nothing has been typed since). Clearing only the draft would leave the
+    // table filtered by search the bar no longer shows.
+    setDraft('');
+    if (search) onChange({ filters, search: '' });
+  }
+
+  /** Backspace on an empty draft steps back out of the phase, then eats chips. */
+  function stepBack() {
+    if (pickedKey) {
+      setPickedKey(null);
+      return;
+    }
+
+    const last = filters[filters.length - 1];
+    if (last) removeFilter(last.id);
+  }
+
   function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (!open) {
-        setOpen(true);
-        return;
-      }
-      const delta = event.key === 'ArrowDown' ? 1 : -1;
-      const next =
-        (highlightIndex + delta + suggestions.length) %
-        Math.max(suggestions.length, 1);
-      setHighlighted(next);
-      // The list scrolls, the input keeps focus: the highlighted row has to
-      // be brought along by hand.
-      document
-        .getElementById(`${id}-option-${next}`)
-        ?.scrollIntoView({ block: 'nearest' });
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      const current = suggestions[highlightIndex];
-      if (open && current) {
-        apply(current);
-      } else {
-        commitDraft(draft);
-        setOpen(false);
-        setPickedKey(null);
-      }
-      return;
-    }
-
-    if (event.key === 'Tab' && open) {
-      const current = suggestions[highlightIndex];
-      if (current && current.kind === 'field') {
+    switch (event.key) {
+      case 'ArrowDown':
         event.preventDefault();
-        apply(current);
-      }
-      return;
-    }
-
-    if (event.key === 'Escape') {
-      if (open) {
-        setOpen(false);
-        setPickedKey(null);
-      } else if (draft) {
-        // The popup is already closed, so this draft is exactly what is
-        // committed (nothing has been typed since). Clearing only the draft
-        // would leave the table filtered by search the bar no longer shows.
-        setDraft('');
-        if (search) onChange({ filters, search: '' });
-      }
-      return;
-    }
-
-    if (event.key === 'Backspace' && draft === '') {
-      // First step out of the picked field, then start eating chips.
-      if (pickedKey) {
-        setPickedKey(null);
-        return;
-      }
-      const last = filters[filters.length - 1];
-      if (last) removeFilter(last.id);
+        moveHighlight(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        moveHighlight(-1);
+        break;
+      case 'Enter':
+        event.preventDefault();
+        commitOrApply();
+        break;
+      case 'Tab':
+        if (open) completeField(event);
+        break;
+      case 'Escape':
+        dismiss();
+        break;
+      case 'Backspace':
+        if (draft === '') stepBack();
+        break;
     }
   }
 

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -423,7 +423,14 @@ function ToastProgress({
   value: number;
   styles: ToastStyles;
 }) {
-  const rounded = Math.round(value);
+  // Normalized once, then used for all three. The bar was already clamped
+  // while `aria-valuenow` and the caption were not, so a caller reporting 150
+  // drew a full bar and announced "150 %" against a declared maximum of 100.
+  // A non-finite value reads as no progress rather than as `NaN %`.
+  const clamped = Number.isFinite(value)
+    ? Math.min(Math.max(value, 0), 100)
+    : 0;
+  const rounded = Math.round(clamped);
 
   return (
     <div
@@ -437,7 +444,7 @@ function ToastProgress({
       <span className={styles.progressTrack()}>
         <span
           className={styles.progressBar()}
-          style={{ width: `${Math.min(Math.max(value, 0), 100)}%` }}
+          style={{ width: `${clamped}%` }}
         />
       </span>
       <span className={styles.progressValue()}>{rounded} %</span>

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -412,6 +412,82 @@ export function useToast(): UseToastReturn {
   );
 }
 
+/** The tone-resolved class slots, which only `ToastRoot` can build. */
+type ToastStyles = ReturnType<typeof toast>;
+
+/** How far along the work is, clamped to the bar it is drawn in. */
+function ToastProgress({
+  value,
+  styles,
+}: {
+  value: number;
+  styles: ToastStyles;
+}) {
+  const rounded = Math.round(value);
+
+  return (
+    <div
+      className={styles.progress()}
+      role="progressbar"
+      aria-label="Progress"
+      aria-valuenow={rounded}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <span className={styles.progressTrack()}>
+        <span
+          className={styles.progressBar()}
+          style={{ width: `${Math.min(Math.max(value, 0), 100)}%` }}
+        />
+      </span>
+      <span className={styles.progressValue()}>{rounded} %</span>
+    </div>
+  );
+}
+
+/**
+ * What can be done about the notice.
+ *
+ * The primary is a `BaseToast.Action` and the secondary is a plain button:
+ * only the first is the toast's own action, and marking both would give a
+ * screen reader two of them.
+ */
+function ToastActions({
+  action,
+  altAction,
+  onRun,
+  styles,
+}: {
+  action: ToastActionSpec | undefined;
+  altAction: ToastActionSpec | undefined;
+  onRun: (spec: ToastActionSpec) => () => void;
+  styles: ToastStyles;
+}) {
+  return (
+    <div className={styles.actions()}>
+      {action ? (
+        <BaseToast.Action
+          onClick={onRun(action)}
+          render={
+            <Button
+              variant={action.strong ? 'primary' : 'secondary'}
+              size="sm"
+              aria-label={action.label}
+            />
+          }
+        >
+          {action.label}
+        </BaseToast.Action>
+      ) : null}
+      {altAction ? (
+        <Button variant="ghost" size="sm" onClick={onRun(altAction)}>
+          {altAction.label}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 function ToastRoot({ toast: item }: { toast: ToastItem }) {
   const { close } = BaseToast.useToastManager<ToastData>();
   const data = item.data;
@@ -450,54 +526,16 @@ function ToastRoot({ toast: item }: { toast: ToastItem }) {
             ) : null}
 
             {progress != null ? (
-              <div
-                className={styles.progress()}
-                role="progressbar"
-                aria-label="Progress"
-                aria-valuenow={Math.round(progress)}
-                aria-valuemin={0}
-                aria-valuemax={100}
-              >
-                <span className={styles.progressTrack()}>
-                  <span
-                    className={styles.progressBar()}
-                    style={{
-                      width: `${Math.min(Math.max(progress, 0), 100)}%`,
-                    }}
-                  />
-                </span>
-                <span className={styles.progressValue()}>
-                  {Math.round(progress)} %
-                </span>
-              </div>
+              <ToastProgress value={progress} styles={styles} />
             ) : null}
 
             {action || altAction ? (
-              <div className={styles.actions()}>
-                {action ? (
-                  <BaseToast.Action
-                    onClick={runAndClose(action)}
-                    render={
-                      <Button
-                        variant={action.strong ? 'primary' : 'secondary'}
-                        size="sm"
-                        aria-label={action.label}
-                      />
-                    }
-                  >
-                    {action.label}
-                  </BaseToast.Action>
-                ) : null}
-                {altAction ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={runAndClose(altAction)}
-                  >
-                    {altAction.label}
-                  </Button>
-                ) : null}
-              </div>
+              <ToastActions
+                action={action}
+                altAction={altAction}
+                onRun={runAndClose}
+                styles={styles}
+              />
             ) : null}
           </div>
 

--- a/packages/ui/src/components/waterfall/waterfall.tsx
+++ b/packages/ui/src/components/waterfall/waterfall.tsx
@@ -325,46 +325,136 @@ function advance(frontier: number | null, ...ends: number[]): number {
  * `guides` says, per ancestor level, whether that ancestor still has
  * siblings below -- which is exactly where a vertical guide line belongs.
  */
+/** One sibling, or a run of them folded into an autogroup. */
+type SiblingUnit =
+  | { unit: 'node'; node: TreeNode }
+  | { unit: 'run'; nodes: TreeNode[] };
+
+/**
+ * Splits a sibling list into single nodes and autogroupable runs.
+ *
+ * A run is `AUTOGROUP_MIN`+ consecutive siblings that are all leaves and all
+ * share an op and description: the N+1 shape. A node with children never joins
+ * one, because folding it would hide the subtree underneath it.
+ */
+function partitionSiblings(list: TreeNode[]): SiblingUnit[] {
+  const units: SiblingUnit[] = [];
+  const keyOf = (node: TreeNode) => `${node.span.op} ${node.span.description}`;
+
+  let index = 0;
+  while (index < list.length) {
+    const node = list[index] as TreeNode;
+    const key = keyOf(node);
+
+    let end = index;
+    while (end + 1 < list.length) {
+      const next = list[end + 1] as TreeNode;
+      const breaksRun =
+        next.children.length > 0 ||
+        node.children.length > 0 ||
+        keyOf(next) !== key;
+      if (breaksRun) break;
+      end += 1;
+    }
+
+    if (end - index + 1 >= AUTOGROUP_MIN) {
+      units.push({ unit: 'run', nodes: list.slice(index, end + 1) });
+      index = end + 1;
+    } else {
+      units.push({ unit: 'node', node });
+      index += 1;
+    }
+  }
+
+  return units;
+}
+
+/** The span a unit starts at, whichever kind of unit it is. */
+function unitStart(entry: SiblingUnit): WaterfallSpan {
+  return entry.unit === 'node'
+    ? entry.node.span
+    : (entry.nodes[0] as TreeNode).span;
+}
+
 function flatten(nodes: TreeNode[], state: FlattenState): Row[] {
   const rows: Row[] = [];
 
-  const walk = (list: TreeNode[], depth: number, guides: boolean[]) => {
-    // First pass: partition the sibling list into single nodes and groups.
-    const units: Array<
-      { unit: 'node'; node: TreeNode } | { unit: 'run'; nodes: TreeNode[] }
-    > = [];
-    let index = 0;
-    while (index < list.length) {
-      const node = list[index] as TreeNode;
-      const key = `${node.span.op} ${node.span.description}`;
-      let end = index;
-      while (end + 1 < list.length) {
-        const next = list[end + 1] as TreeNode;
-        if (
-          next.children.length > 0 ||
-          node.children.length > 0 ||
-          `${next.span.op} ${next.span.description}` !== key
-        ) {
-          break;
-        }
-        end += 1;
+  /** Pushes one autogrouped run, open or folded. Returns the new frontier. */
+  const emitRun = (
+    entryNodes: TreeNode[],
+    depth: number,
+    guides: boolean[],
+    last: boolean,
+    frontier: number | null,
+  ): number => {
+    const spans = entryNodes.map((n) => n.span);
+    const head = spans[0] as WaterfallSpan;
+    const groupId = `group-${head.id}`;
+
+    if (state.openGroups.has(groupId)) {
+      for (const node of entryNodes) {
+        rows.push({
+          kind: 'span',
+          id: node.span.id,
+          span: node.span,
+          depth,
+          guides: [...guides, !last],
+          hasChildren: false,
+          collapsed: false,
+          count: 0,
+        });
       }
-      if (end - index + 1 >= AUTOGROUP_MIN) {
-        units.push({ unit: 'run', nodes: list.slice(index, end + 1) });
-        index = end + 1;
-      } else {
-        units.push({ unit: 'node', node });
-        index += 1;
-      }
+    } else {
+      rows.push({
+        kind: 'group',
+        id: groupId,
+        op: head.op ?? 'span',
+        description: head.description,
+        spans,
+        depth,
+        guides: [...guides, !last],
+        failed: spans.some((s) => s.status && s.status !== 'ok'),
+      });
     }
 
+    return advance(frontier, ...spans.map((s) => s.endMs));
+  };
+
+  /** Pushes one span and, when it is open, its children. Returns the frontier. */
+  const emitNode = (
+    node: TreeNode,
+    depth: number,
+    guides: boolean[],
+    last: boolean,
+    frontier: number | null,
+  ): number => {
+    const isCollapsed = state.collapsed.has(node.span.id);
+
+    rows.push({
+      kind: 'span',
+      id: node.span.id,
+      span: node.span,
+      depth,
+      guides: [...guides, !last],
+      hasChildren: node.children.length > 0,
+      collapsed: isCollapsed,
+      count: descendants(node),
+    });
+
+    if (node.children.length > 0 && !isCollapsed) {
+      walk(node.children, depth + 1, [...guides, !last]);
+    }
+
+    return advance(frontier, node.span.endMs);
+  };
+
+  const walk = (list: TreeNode[], depth: number, guides: boolean[]) => {
+    const units = partitionSiblings(list);
     let previousEnd: number | null = null;
+
     units.forEach((entry, unitIndex) => {
       const last = unitIndex === units.length - 1;
-      const first =
-        entry.unit === 'node'
-          ? entry.node.span
-          : (entry.nodes[0] as TreeNode).span;
+      const first = unitStart(entry);
 
       if (
         state.showGaps &&
@@ -381,55 +471,10 @@ function flatten(nodes: TreeNode[], state: FlattenState): Row[] {
         });
       }
 
-      if (entry.unit === 'run') {
-        const spans = entry.nodes.map((n) => n.span);
-        const head = spans[0] as WaterfallSpan;
-        const groupId = `group-${head.id}`;
-        if (state.openGroups.has(groupId)) {
-          for (const node of entry.nodes) {
-            rows.push({
-              kind: 'span',
-              id: node.span.id,
-              span: node.span,
-              depth,
-              guides: [...guides, !last],
-              hasChildren: false,
-              collapsed: false,
-              count: 0,
-            });
-          }
-        } else {
-          rows.push({
-            kind: 'group',
-            id: groupId,
-            op: head.op ?? 'span',
-            description: head.description,
-            spans,
-            depth,
-            guides: [...guides, !last],
-            failed: spans.some((s) => s.status && s.status !== 'ok'),
-          });
-        }
-        previousEnd = advance(previousEnd, ...spans.map((s) => s.endMs));
-        return;
-      }
-
-      const node = entry.node;
-      const isCollapsed = state.collapsed.has(node.span.id);
-      rows.push({
-        kind: 'span',
-        id: node.span.id,
-        span: node.span,
-        depth,
-        guides: [...guides, !last],
-        hasChildren: node.children.length > 0,
-        collapsed: isCollapsed,
-        count: descendants(node),
-      });
-      if (node.children.length > 0 && !isCollapsed) {
-        walk(node.children, depth + 1, [...guides, !last]);
-      }
-      previousEnd = advance(previousEnd, node.span.endMs);
+      previousEnd =
+        entry.unit === 'run'
+          ? emitRun(entry.nodes, depth, guides, last, previousEnd)
+          : emitNode(entry.node, depth, guides, last, previousEnd);
     });
   };
 
@@ -818,61 +863,47 @@ function RowBars({
 RowBars.displayName = 'RowBars';
 
 /** One span, or one autogrouped run of them, on the shared clock. */
-function SpanRow({
-  row,
-  start,
-  total,
-  tabStop,
-  selected,
-  onSelect,
-  renderDetail,
-  onToggle,
-  moveFocus,
-}: {
-  row: SpanRowData;
-  start: number;
-  total: number;
-  tabStop: boolean;
-  selected: boolean;
-  onSelect?: (span: WaterfallSpan | null) => void;
-  renderDetail?: (span: WaterfallSpan) => ReactNode;
-  onToggle: (id: string) => void;
+/**
+ * How a row reads: whether it failed, and which palette it draws in.
+ *
+ * A group takes the error look as soon as any span in it failed, because the
+ * one that did is the reason someone is looking at the group at all.
+ */
+function rowAppearance(row: SpanRowData): { failed: boolean; kind: SpanKind } {
+  if (row.kind === 'group') {
+    return {
+      failed: row.failed,
+      kind: row.failed ? 'error' : spanKind(row.spans[0] as WaterfallSpan),
+    };
+  }
+
+  const kind = spanKind(row.span);
+  return { failed: kind === 'error', kind };
+}
+
+interface RowKeyActions {
+  select: () => void;
+  toggle: () => void;
   moveFocus: (from: HTMLElement, delta: number | 'home' | 'end') => void;
-}) {
-  const spans = row.kind === 'group' ? row.spans : [row.span];
-  const rowStart = Math.min(...spans.map((s) => s.startMs));
-  const rowEnd = Math.max(...spans.map((s) => s.endMs));
-  const failed =
-    row.kind === 'group' ? row.failed : spanKind(row.span) === 'error';
-  const kind: SpanKind =
-    row.kind === 'group'
-      ? failed
-        ? 'error'
-        : spanKind(row.spans[0] as WaterfallSpan)
-      : spanKind(row.span);
+  expandable: boolean;
+  isOpen: boolean;
+}
 
-  const left = ((rowStart - start) / total) * 100;
-  // A 2 ms span in a 600 ms trace still has to be visible: it may be the
-  // one that threw.
-  const width = Math.min(
-    Math.max(((rowEnd - rowStart) / total) * 100, 0.6),
-    100 - left,
-  );
-
-  const expandable = row.kind === 'group' || row.hasChildren;
-  const isOpen = row.kind === 'span' && row.hasChildren && !row.collapsed;
-  const toggle = () => {
-    if (expandable) onToggle(row.id);
-  };
-  const select = () => {
-    if (row.kind !== 'span') {
-      toggle();
-      return;
-    }
-    onSelect?.(selected ? null : row.span);
-  };
-
-  const onRowKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+/**
+ * The treeitem keyboard contract, in one place.
+ *
+ * Arrow right opens and arrow left closes rather than toggling: that is what
+ * the ARIA tree pattern specifies, and it is why these two are the only keys
+ * here that do nothing when the row is already in the state they ask for.
+ */
+function rowKeyHandler({
+  select,
+  toggle,
+  moveFocus,
+  expandable,
+  isOpen,
+}: RowKeyActions) {
+  return (event: KeyboardEvent<HTMLElement>) => {
     switch (event.key) {
       case 'Enter':
       case ' ':
@@ -903,6 +934,62 @@ function SpanRow({
         break;
     }
   };
+}
+
+function SpanRow({
+  row,
+  start,
+  total,
+  tabStop,
+  selected,
+  onSelect,
+  renderDetail,
+  onToggle,
+  moveFocus,
+}: {
+  row: SpanRowData;
+  start: number;
+  total: number;
+  tabStop: boolean;
+  selected: boolean;
+  onSelect?: (span: WaterfallSpan | null) => void;
+  renderDetail?: (span: WaterfallSpan) => ReactNode;
+  onToggle: (id: string) => void;
+  moveFocus: (from: HTMLElement, delta: number | 'home' | 'end') => void;
+}) {
+  const spans = row.kind === 'group' ? row.spans : [row.span];
+  const rowStart = Math.min(...spans.map((s) => s.startMs));
+  const rowEnd = Math.max(...spans.map((s) => s.endMs));
+  const { failed, kind } = rowAppearance(row);
+
+  const left = ((rowStart - start) / total) * 100;
+  // A 2 ms span in a 600 ms trace still has to be visible: it may be the
+  // one that threw.
+  const width = Math.min(
+    Math.max(((rowEnd - rowStart) / total) * 100, 0.6),
+    100 - left,
+  );
+
+  const expandable = row.kind === 'group' || row.hasChildren;
+  const isOpen = row.kind === 'span' && row.hasChildren && !row.collapsed;
+  const toggle = () => {
+    if (expandable) onToggle(row.id);
+  };
+  const select = () => {
+    if (row.kind !== 'span') {
+      toggle();
+      return;
+    }
+    onSelect?.(selected ? null : row.span);
+  };
+
+  const onRowKeyDown = rowKeyHandler({
+    select,
+    toggle,
+    moveFocus,
+    expandable,
+    isOpen,
+  });
 
   const onRowClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement;


### PR DESCRIPTION
## What this is

`biome.json` turns on `noExcessiveCognitiveComplexity` at the default ceiling of
15. That surfaced **28 violations** across `apps/webview-ui` and `packages/ui`,
and this PR clears all of them.

**No `biome-ignore` anywhere.** A complexity rule that gets waived in place is
worse than no rule, because it reads as enforced while the exceptions accumulate.

One framing point that shaped the whole approach: Biome measures *cognitive*
complexity, not cyclomatic. It weights **nesting**, so `if` inside `if` inside a
`.map()` costs 1+2+3 while three sibling `if`s cost 1+1+1. Flattening therefore
pays far more than deleting branches, and every refactor below moves work into
named units rather than compressing it.

## The 28 were six shapes, not 28 problems

| Pattern | Count | Worst | Fix |
|---|---|---|---|
| Inline `.map()` row renderers | 7 | 27 | Named row components + shared `barGeometry` |
| Keyboard handlers as if-chains | 4 | **35** | Key-to-intent dispatch |
| Provider-type validation chains | 3 | 25 | `Record<ProviderType, ...>` strategy table |
| Triplicated form `onSubmit` | 3 | 21 | One `useIntegrationSubmit` hook |
| Server page: load + derive + render | 3 | 25 | Pure, tested derivation functions |
| Query codecs and fixtures | 5 | **61** | `FilterCodec` / predicate tables |

### The two that mattered most

**`fakeServer` at 61** (`data-table.stories.tsx`) was an if-chain per column
inside a `.filter()`. It is now a `MATCHERS` predicate table. Worth doing even in
a story file, because that fake server is the de facto documentation of the
filter behaviour the Rust endpoint is expected to match, and at 61 nobody was
reading it.

**`onKeyDown` at 35** (`use-query-bar.ts`) was six sequential
`if (event.key === ...)` blocks with nested branches inside each. It is now a
flat `switch` delegating to five named intents (`moveHighlight`, `commitOrApply`,
`completeField`, `dismiss`, `stepBack`), none above 5.

### Type safety gained on the way

Three of the patterns replace an if-chain with a keyed table, and the key type is
the point rather than a side effect:

- `Record<ProviderType, RoutingBehaviour>` in `routing.ts`
- `Record<ColumnFilterSpec['variant'], FilterCodec>` in `query.ts`
- `Record<ColumnFilterSpec['variant'], Panel>` in `column-header.tsx`

Adding a provider or a filter variant is now a **compile error** until it is
handled everywhere. The if-chains it replaces silently fell through, which is how
`routing.ts` ended up with the same `provider_type` chain written three times in
three functions, where adding a provider was three edits and nothing failed if
only two of them happened.

## Behaviour is unchanged, and that is tested

Every structural refactor landed either test-first or behind characterization
tests written against the existing code **before** it was touched. That is what
the **93 new unit tests** are:

`routing` (29), `integration-forms` (13), `trace-summary` (12), `transaction-payload` (8),
`waterfall-geometry` (8), `detectPhase` (7), `credentials` (6), `event-jumps` (4),
`setup-snippet` (4), plus 2 pinning existing `query.ts` edge cases.

- `packages/ui`: 92 to 185 tests
- `apps/webview-ui`: 92 to 170 tests
- `pnpm run ci`: 27/27 green, Rust suite included

## One regression, caught by the Storybook tests

Extracting the column header's trigger `<button>` into its own component broke
three Storybook interaction tests. Base UI's `Popover.Trigger` takes the element
through a `render` prop and **merges** the click handler, the ref and
`data-popup-open` into it. A function component received all of that as props it
did not forward, leaving a button that never opened its popover.

Neither TypeScript nor the linter would have caught it. The `<button>` element is
back inline with a comment explaining why it cannot move, and only its children
are extracted. Worth flagging as an argument for keeping those play tests.

## Two pre-existing issues found

**`buildChannelsPayload` was quadratic.** It searched with `integrations.find()`
inside a `flatMap` over the selection, directly below `collectRoutingErrors`,
which had already indexed the same pair with a `Map` and carried a comment
explaining why. It uses the `Map` now.

**An undocumented asymmetry in the query parser.** `level:,,` (a malformed option
list) is silently dropped, while `events:oops` (a malformed range) is kept as free
text. Nothing tested it and nothing said it was deliberate. Both are now pinned by
tests and the third outcome is named `drop` in the codec type, so the difference
is stated rather than implied. **The behaviour itself is unchanged**, by request.

## Also in here

**`vitest.config.mts` gains a `@/` alias.** Type-only `@/` imports are erased at
compile time, so its absence never showed until a test's subject imported a real
*value* through one, which fails as "Cannot find package" rather than as missing
config. That file is deliberately minimal and heavily commented, so the addition
says exactly which gap it closes.

**A separate commit fixes CI on non-`main` PRs.** `branches:` under a
`pull_request` trigger filters on the PR's *base*, so gating on `main` meant a PR
onto a feature branch ran no CI, no CodeQL and no cargo-deny at all. CodeRabbit
had the same problem from its side: it only reviews PRs onto the default branch
unless given `base_branches`. Both are fixed.

> Note: branch protection is configured in GitHub, not in the repo. These checks
> now *run* on such PRs; whether they *block* a merge is a separate setting worth
> checking.

## Reviewing this

The diff is large but repetitive: seven row extractions and three table
conversions account for most of it. The parts worth real attention are
`routing.ts`, `query.ts` and `use-integration-submit.ts`, where the shape of the
code actually changed rather than just its location.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved event detail pages with sticky headers, navigation, jump links, timestamps, release information, and activity summaries.
  * Added clearer agent trace summaries, span selection states, detail panes, and waterfall visualizations.
  * Improved transaction detail badges and project client-key setup instructions.
  * Added reliable copy feedback, including clipboard-unavailable notifications.

* **Bug Fixes**
  * Improved alert integration submissions, validation, credential handling, and error display.
  * Improved query filtering for empty options and malformed ranges.
  * Improved waterfall bar positioning and keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->