### PR TITLE
fix(server): fail with a clear error on a short SESSION_SECRET_KEY

### DIFF
--- a/apps/docs/content/configuration/environment.mdx
+++ b/apps/docs/content/configuration/environment.mdx
@@ -242,7 +242,7 @@ DATABASE_URL=postgres://rustrak:password@postgres:5432/rustrak
 
 # Security (required for production behind HTTPS proxy)
 SSL_PROXY=true
-SESSION_SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
+SESSION_SECRET_KEY=generate-your-own-with-openssl-rand-hex-32
 
 # Server
 PORT=8080

--- a/apps/docs/content/configuration/environment.mdx
+++ b/apps/docs/content/configuration/environment.mdx
@@ -42,7 +42,7 @@ DATABASE_URL=postgres://user:pass@host:5432/rustrak?sslmode=require  # With SSL
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SSL_PROXY` | `false` | Set to `true` when behind HTTPS proxy (nginx, Cloudflare) |
-| `SESSION_SECRET_KEY` | (random) | 64-character hex string for session encryption |
+| `SESSION_SECRET_KEY` | (random) | 64-character key for session encryption |
 
 ### SSL_PROXY
 
@@ -65,6 +65,12 @@ openssl rand -hex 32
 
 - **Development**: Optional (a random key is used, sessions don't persist across restarts)
 - **Production with `SSL_PROXY=true`**: Required
+
+The key must be at least 64 characters, which is what `openssl rand -hex 32`
+produces: the cookie key is a 256-bit signing key followed by a 256-bit
+encryption key. Anything shorter is refused at startup with the length it
+received, so `openssl rand -base64 32` (44 characters) will not do. Changing the
+key invalidates every existing session.
 
 ## Server
 

--- a/apps/docs/content/configuration/production.mdx
+++ b/apps/docs/content/configuration/production.mdx
@@ -6,11 +6,15 @@ Essential steps before going live.
 
 ### 1. Generate secure secrets
 
-```bash
-# Session secret (required when using HTTPS)
-openssl rand -hex 32
+Session secret, required when using HTTPS:
 
-# Database password
+```bash
+openssl rand -hex 32
+```
+
+Database password (do not reuse this one as the session secret):
+
+```bash
 openssl rand -base64 24
 ```
 

--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -109,8 +109,8 @@ POSTGRES_DB=rustrak
 SERVER_PORT=8080
 RUST_LOG=info
 
-# Session secret (required) - generate with: openssl rand -hex 32
-SESSION_SECRET_KEY=your-64-char-hex-secret-here
+# Session secret (required) - replace with your own: openssl rand -hex 32
+SESSION_SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
 
 # Admin user (required) - format: email:password
 CREATE_SUPERUSER=admin@example.com:changeme123

--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -109,8 +109,9 @@ POSTGRES_DB=rustrak
 SERVER_PORT=8080
 RUST_LOG=info
 
-# Session secret (required) - replace with your own: openssl rand -hex 32
-SESSION_SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
+# Session secret (required) - replace with the output of: openssl rand -hex 32
+# The server refuses to start until you do.
+SESSION_SECRET_KEY=generate-your-own-with-openssl-rand-hex-32
 
 # Admin user (required) - format: email:password
 CREATE_SUPERUSER=admin@example.com:changeme123

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -25,7 +25,8 @@ DATABASE_URL=postgres://rustrak:rustrak@localhost:5432/rustrak
 # Session Security
 # Generate with: openssl rand -hex 32
 # Required when SSL_PROXY=true, optional otherwise (random key used if not set)
-# SESSION_SECRET_KEY=your-random-64-char-secret-key-here
+# Must be at least 64 characters; the server refuses to start below that
+# SESSION_SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
 
 # Bootstrap Superuser (optional - only on first startup)
 # Format: email:password

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -26,7 +26,7 @@ DATABASE_URL=postgres://rustrak:rustrak@localhost:5432/rustrak
 # Generate with: openssl rand -hex 32
 # Required when SSL_PROXY=true, optional otherwise (random key used if not set)
 # Must be at least 64 characters; the server refuses to start below that
-# SESSION_SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
+# SESSION_SECRET_KEY=generate-your-own-with-openssl-rand-hex-32
 
 # Bootstrap Superuser (optional - only on first startup)
 # Format: email:password

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -34,7 +34,7 @@ cargo run
 docker pull rustrak/rustrak-server
 docker run -d -p 8080:8080 \
   -e DATABASE_URL="postgres://user:pass@localhost:5432/rustrak" \
-  -e SESSION_SECRET_KEY="your-secret-key" \
+  -e SESSION_SECRET_KEY="$(openssl rand -hex 32)" \
   rustrak/rustrak-server
 ```
 

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -1,3 +1,4 @@
+use actix_web::cookie::Key;
 use std::env;
 use std::time::Duration;
 
@@ -40,13 +41,27 @@ pub struct DatabaseConfig {
 }
 
 /// Security configuration for production deployments
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SecurityConfig {
     /// True if server is behind a proxy that terminates SSL (nginx, Cloudflare, etc.)
     /// When true: cookie_secure=true is enabled
     pub ssl_proxy: bool,
     /// Session encryption key (64 hex chars). Required when ssl_proxy=true
     pub session_secret_key: Option<String>,
+}
+
+impl std::fmt::Debug for SecurityConfig {
+    /// Hand-written so the secret cannot reach a log line through the derived
+    /// `Debug` on `Config`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecurityConfig")
+            .field("ssl_proxy", &self.ssl_proxy)
+            .field(
+                "session_secret_key",
+                &self.session_secret_key.as_ref().map(|_| "[redacted]"),
+            )
+            .finish()
+    }
 }
 
 /// Rate limiting configuration
@@ -175,6 +190,7 @@ pub enum ConfigError {
     InvalidPort,
     MissingDatabaseUrl,
     MissingSessionSecret,
+    SessionSecretTooShort { len: usize },
 }
 
 impl std::fmt::Display for ConfigError {
@@ -190,6 +206,14 @@ impl std::fmt::Display for ConfigError {
                     "SESSION_SECRET_KEY is required when SSL_PROXY is enabled"
                 )
             }
+            ConfigError::SessionSecretTooShort { len } => {
+                write!(
+                    f,
+                    "SESSION_SECRET_KEY is {len} bytes, but at least {min} are required. \
+                     Generate one with: openssl rand -hex 32",
+                    min = SecurityConfig::MIN_SECRET_LEN
+                )
+            }
         }
     }
 }
@@ -197,6 +221,10 @@ impl std::fmt::Display for ConfigError {
 impl std::error::Error for ConfigError {}
 
 impl SecurityConfig {
+    /// Required length of `SESSION_SECRET_KEY`, in bytes: the cookie master key
+    /// is a 256-bit signing key followed by a 256-bit encryption key.
+    pub const MIN_SECRET_LEN: usize = 64;
+
     /// Load security configuration from environment variables
     pub fn from_env() -> Result<Self, ConfigError> {
         let session_secret_key = env::var("SESSION_SECRET_KEY").ok();
@@ -210,9 +238,33 @@ impl SecurityConfig {
             return Err(ConfigError::MissingSessionSecret);
         }
 
+        // Build the key here so an unusable secret stops the process before it
+        // opens the database, runs migrations and starts the workers.
+        if let Some(secret) = &session_secret_key {
+            Self::key_from_secret(secret)?;
+        }
+
         Ok(Self {
             ssl_proxy,
             session_secret_key,
         })
+    }
+
+    /// Builds the master key used to sign and encrypt session cookies.
+    pub fn session_key(&self) -> Result<Key, ConfigError> {
+        match &self.session_secret_key {
+            Some(secret) => Self::key_from_secret(secret),
+            None => Ok(Key::generate()),
+        }
+    }
+
+    fn key_from_secret(secret: &str) -> Result<Key, ConfigError> {
+        let bytes = secret.as_bytes();
+
+        if bytes.len() < Self::MIN_SECRET_LEN {
+            return Err(ConfigError::SessionSecretTooShort { len: bytes.len() });
+        }
+
+        Ok(Key::from(bytes))
     }
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -1,6 +1,6 @@
 use actix_cors::Cors;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
-use actix_web::{cookie::Key, middleware, web, App, HttpServer};
+use actix_web::{middleware, web, App, HttpServer};
 
 use std::sync::Arc;
 
@@ -61,6 +61,18 @@ async fn main() -> std::io::Result<()> {
 
     log::info!("Starting Rustrak server on {}:{}", config.host, config.port);
 
+    // Built before any I/O: an unusable secret must stop the process here, not
+    // after migrations have run and the workers are up.
+    if config.security.session_secret_key.is_none() {
+        log::warn!(
+            "SESSION_SECRET_KEY not set, using random key (sessions won't persist across restarts)"
+        );
+    }
+    let key = config.security.session_key().map_err(|e| {
+        log::error!("Configuration error: {}", e);
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
+    })?;
+
     let ingest_dir = rustrak::ingest::get_ingest_dir(config.ingest_dir.as_deref());
     rustrak::ingest::prepare_ingest_dir(&ingest_dir)
         .await
@@ -117,21 +129,6 @@ async fn main() -> std::io::Result<()> {
     if let Err(e) = bootstrap::create_superuser_if_needed(&db_pool).await {
         log::error!("Failed to create superuser: {}", e);
     }
-
-    // Session secret key from config or generate random (with warning)
-    let secret_key = match &config.security.session_secret_key {
-        Some(key) => key.clone(),
-        None => {
-            log::warn!(
-                "SESSION_SECRET_KEY not set, using random key (sessions won't persist across restarts)"
-            );
-            use rand::RngExt;
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::rng().random()).collect();
-            hex::encode(random_bytes)
-        }
-    };
-
-    let key = Key::from(secret_key.as_bytes());
 
     // Clone values for the closure
     let host = config.host.clone();

--- a/apps/server/tests/unit/config_test.rs
+++ b/apps/server/tests/unit/config_test.rs
@@ -4,7 +4,8 @@
 //!
 //! Note: These tests modify global environment variables and must run serially.
 
-use rustrak::config::{Config, RateLimitConfig};
+use actix_web::cookie::Key;
+use rustrak::config::{Config, RateLimitConfig, SecurityConfig};
 use serial_test::serial;
 
 // =============================================================================
@@ -192,4 +193,182 @@ fn test_config_public_url_empty_string_treated_as_none() {
         Some(v) => std::env::set_var("PUBLIC_URL", v),
         None => std::env::remove_var("PUBLIC_URL"),
     }
+}
+
+// =============================================================================
+// SESSION_SECRET_KEY Tests
+// =============================================================================
+
+/// Restores SESSION_SECRET_KEY and SSL_PROXY to their pre-test values on drop,
+/// so a failing assertion cannot leak state into the next serial test.
+struct SessionEnv {
+    secret: Option<String>,
+    ssl_proxy: Option<String>,
+}
+
+impl SessionEnv {
+    fn set(secret: Option<&str>) -> Self {
+        let guard = Self {
+            secret: std::env::var("SESSION_SECRET_KEY").ok(),
+            ssl_proxy: std::env::var("SSL_PROXY").ok(),
+        };
+        std::env::remove_var("SSL_PROXY");
+        match secret {
+            Some(value) => std::env::set_var("SESSION_SECRET_KEY", value),
+            None => std::env::remove_var("SESSION_SECRET_KEY"),
+        }
+        guard
+    }
+}
+
+impl Drop for SessionEnv {
+    fn drop(&mut self) {
+        match &self.secret {
+            Some(value) => std::env::set_var("SESSION_SECRET_KEY", value),
+            None => std::env::remove_var("SESSION_SECRET_KEY"),
+        }
+        match &self.ssl_proxy {
+            Some(value) => std::env::set_var("SSL_PROXY", value),
+            None => std::env::remove_var("SSL_PROXY"),
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn test_session_secret_shorter_than_64_bytes_is_rejected_at_load() {
+    let _env = SessionEnv::set(Some("too-short-secret-key"));
+
+    let result = SecurityConfig::from_env();
+
+    assert!(
+        result.is_err(),
+        "a 20-byte secret must be rejected at load, not panic later in the cookie crate"
+    );
+}
+
+#[test]
+#[serial]
+fn test_session_secret_too_short_error_names_the_variable_and_the_fix() {
+    let _env = SessionEnv::set(Some("too-short-secret-key"));
+
+    let message = SecurityConfig::from_env()
+        .expect_err("a 20-byte secret must be rejected")
+        .to_string();
+
+    assert!(
+        message.contains("SESSION_SECRET_KEY"),
+        "the operator must be told which variable is wrong, got: {message}"
+    );
+    assert!(
+        message.contains("20"),
+        "the operator must be told the length we actually received, got: {message}"
+    );
+    assert!(
+        message.contains("64"),
+        "the operator must be told the minimum accepted length, got: {message}"
+    );
+    assert!(
+        message.contains("openssl rand -hex 32"),
+        "the operator must be told how to generate a valid key, got: {message}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_secret_of_64_bytes_keeps_the_key_existing_sessions_were_signed_with() {
+    // What `openssl rand -hex 32` produces, and what every current deployment runs.
+    let secret = "0123456789abcdef".repeat(4);
+    assert_eq!(secret.len(), 64);
+    let _env = SessionEnv::set(Some(&secret));
+
+    let key = SecurityConfig::from_env()
+        .expect("a 64-byte secret must load")
+        .session_key()
+        .expect("a 64-byte secret must build a key");
+
+    // `Key` has no Debug impl, so compare with assert! rather than assert_eq!.
+    assert!(
+        key == Key::from(secret.as_bytes()),
+        "keys of 64 bytes or more must be used verbatim, otherwise upgrading logs everyone out"
+    );
+}
+
+/// Regression guard for rustrak/rustrak#298: the reporter set a 44-byte key,
+/// which is what `openssl rand -base64 32` produces, and the server crash-looped
+/// on `TooShort(44)` from the cookie crate after migrations had already run.
+/// The key is still refused, but now it is refused in a way the operator can act on.
+#[test]
+#[serial]
+fn test_secret_of_44_bytes_from_base64_is_refused_with_a_usable_message() {
+    let secret = "sB5nQm0dK9xTfR2wV7yZaL4pC8jH1gE6uN3oI0kM5tQ=";
+    assert_eq!(secret.len(), 44);
+    let _env = SessionEnv::set(Some(secret));
+
+    let message = SecurityConfig::from_env()
+        .expect_err("a 44-byte secret must be refused, not panic in the cookie crate")
+        .to_string();
+
+    assert!(
+        message.contains("SESSION_SECRET_KEY") && message.contains("44"),
+        "the message must name the variable and the length received, got: {message}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_same_secret_builds_the_same_key_so_sessions_survive_a_restart() {
+    let secret = "0123456789abcdef".repeat(4);
+    let _env = SessionEnv::set(Some(&secret));
+
+    let first = SecurityConfig::from_env().unwrap().session_key().unwrap();
+    let second = SecurityConfig::from_env().unwrap().session_key().unwrap();
+
+    assert!(first == second, "a fixed secret must be deterministic");
+}
+
+#[test]
+#[serial]
+fn test_no_secret_builds_a_random_key_per_start() {
+    let _env = SessionEnv::set(None);
+
+    let first = SecurityConfig::from_env().unwrap().session_key().unwrap();
+    let second = SecurityConfig::from_env().unwrap().session_key().unwrap();
+
+    assert!(
+        first != second,
+        "without a configured secret each start must get its own key"
+    );
+}
+
+#[test]
+#[serial]
+fn test_debug_output_does_not_leak_the_session_secret() {
+    let secret = "0123456789abcdef".repeat(4);
+    let _env = SessionEnv::set(Some(&secret));
+
+    let rendered = format!("{:?}", SecurityConfig::from_env().unwrap());
+
+    assert!(
+        !rendered.contains(&secret),
+        "the session secret must never reach a log line, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("ssl_proxy"),
+        "the rest of the config must still be inspectable, got: {rendered}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_ssl_proxy_still_requires_a_session_secret() {
+    let _env = SessionEnv::set(None);
+    std::env::set_var("SSL_PROXY", "true");
+
+    let result = SecurityConfig::from_env();
+
+    assert!(
+        result.is_err(),
+        "a secure-cookie deployment must not fall back to a per-start random key"
+    );
 }


### PR DESCRIPTION
Closes #298

## Problem

    thread 'main' panicked at cookie-0.16.2/src/secure/key.rs:63:28:
    called `Result::unwrap()` on an `Err` value: TooShort(44)

`Key::from` panics below 64 bytes. We called it with whatever
`SESSION_SECRET_KEY` held, after the pool, the migrations and the
workers were up. The panic never named the variable at fault, and the
restart policy turned it into a loop.

44 bytes is `openssl rand -base64 32`. `openssl rand -hex 32`, which we
document, produces 64 and was never the problem.

## Now

    ERROR rustrak] Configuration error: SESSION_SECRET_KEY is 44 bytes, but at
    least 64 are required. Generate one with: openssl rand -hex 32
    exit 1

The server still refuses to start, but the message is ours, it names the
fix, and it happens before the database is touched.

Also: `SecurityConfig`'s derived `Debug` printed the whole secret, now
`[redacted]`. And four docs placeholders were under 64 characters and
crashed if pasted verbatim, the worst being the `.env` template for the
Compose path this reporter followed.

## Why not accept shorter keys with HKDF

`Key::derive_from` would take 32 bytes, roughly what Django does with
`SECRET_KEY`. Rejected: HKDF expands but adds no entropy, so a 32-char
floor accepts a weak passphrase for the key that signs and encrypts
session cookies, where a forgery is a full account takeover. The bug was
never the rejection, it was the unreadable panic.

## Verification

Verified against the built binary, not only the tests. Seven tests in
`tests/unit/config_test.rs`, each written failing first. Full
`cargo test` green (258 + 10 + 407 + 382), clippy and fmt clean.

Docs site build could not run here (no `node_modules`), so the `.mdx`
edits are unverified by build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that session secrets must be at least 64 characters and changing them invalidates existing sessions.
  * Updated production and Docker setup examples to generate unique session secrets and database passwords.
  * Added warnings against reusing credentials and clarified recommended commands.

* **Security Improvements**
  * Session secrets are validated during startup and excluded from diagnostic output.
  * Invalid or insufficient secrets now produce actionable configuration errors.
  * Unconfigured sessions use a secure, newly generated key on each startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->