### PR TITLE
fix(server): read message.formatted and split the issue title from grouping

### DIFF
--- a/apps/server/Cargo.lock
+++ b/apps/server/Cargo.lock
@@ -1261,6 +1261,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0190d4a4c42bc9acca391f32d9c37db37d7608190a698a78d59a996043d9a7b"
+dependencies = [
+ "erased-serde",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1335,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -3518,6 +3542,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "dotenvy",
+ "dynfmt",
  "env_logger",
  "flate2",
  "futures-util",
@@ -4715,6 +4740,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -81,6 +81,9 @@ bytes = "1.12.1"
 # Hashing (for grouping key hash)
 sha2 = "0.11.0"
 
+# formatting edge cases match.
+dynfmt = { version = "0.2", features = ["python", "curly"] }
+
 # IP address handling (stored as string for SQLite compat)
 # ipnetwork removed - store IP as String for multi-DB support
 

--- a/apps/server/src/services/grouping.rs
+++ b/apps/server/src/services/grouping.rs
@@ -204,7 +204,14 @@ fn get_log_message(event_data: &Value, preference: MessagePreference) -> Option<
             return Some(first_line(msg));
         }
 
-        let field = |name: &str| entry.get(name).and_then(|m| m.as_str());
+        // Sentry reads these with `or`, where an empty string is falsy and the
+        // next option is tried, so an empty field must not shadow a usable one.
+        let field = |name: &str| {
+            entry
+                .get(name)
+                .and_then(|m| m.as_str())
+                .filter(|m| !m.is_empty())
+        };
         let picked = match preference {
             MessagePreference::Grouping => field("message").or_else(|| field("formatted")),
             MessagePreference::Title => {

--- a/apps/server/src/services/grouping.rs
+++ b/apps/server/src/services/grouping.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+
+use dynfmt::{Argument, Format, FormatArgs, PythonFormat, SimpleCurlyFormat};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -6,7 +9,8 @@ const GROUPING_SEPARATOR: &str = " ⋄ ";
 
 /// Calculates the grouping key for an event
 pub fn calculate_grouping_key(event_data: &Value) -> String {
-    let (calculated_type, calculated_value) = get_type_and_value(event_data);
+    let (calculated_type, calculated_value) =
+        type_and_value(event_data, MessagePreference::Grouping);
     let transaction = get_transaction(event_data);
 
     // Check for custom fingerprint. An empty fingerprint (sent as `[]` by
@@ -81,8 +85,12 @@ pub fn hash_grouping_key(grouping_key: &str) -> String {
     hex::encode(hasher.finalize())
 }
 
-/// Extracts type and value from the event
+/// Extracts the type and value used to title the issue.
 pub fn get_type_and_value(event_data: &Value) -> (String, String) {
+    type_and_value(event_data, MessagePreference::Title)
+}
+
+fn type_and_value(event_data: &Value, preference: MessagePreference) -> (String, String) {
     // Try to extract from exception, unless it is synthetic. Relay ignores the
     // type/value of synthetic exceptions (signal/segfault wrappers) for
     // grouping and falls through to the next component
@@ -104,7 +112,7 @@ pub fn get_type_and_value(event_data: &Value) -> (String, String) {
     }
 
     // Try to extract from logentry/message
-    if let Some(message) = get_log_message(event_data) {
+    if let Some(message) = get_log_message(event_data, preference) {
         return ("Log Message".to_string(), truncate(&message, 1024));
     }
 
@@ -136,25 +144,86 @@ fn is_synthetic(exception: &Value) -> bool {
         .unwrap_or(false)
 }
 
-/// Gets the log message
-fn get_log_message(event_data: &Value) -> Option<String> {
-    // Try logentry.message or logentry.formatted
-    if let Some(logentry) = event_data.get("logentry") {
-        if let Some(msg) = logentry.get("message").and_then(|m| m.as_str()) {
-            return Some(msg.lines().next().unwrap_or("").to_string());
-        }
-        if let Some(msg) = logentry.get("formatted").and_then(|m| m.as_str()) {
-            return Some(msg.lines().next().unwrap_or("").to_string());
+/// Grouping takes the template so every rendering lands in one issue; the title
+/// takes the rendered text.
+#[derive(Clone, Copy)]
+enum MessagePreference {
+    Grouping,
+    Title,
+}
+
+/// Renders `message` with `params`, the way an SDK would have rendered
+/// `formatted` itself. Returns `None` when the template takes no parameters or
+/// the parameters do not fit it, leaving the template as the best text we have.
+fn format_message(template: &str, params: &Value) -> Option<String> {
+    let args = ParamArgs(params);
+    if template.contains('%') {
+        PythonFormat
+            .format(template, args)
+            .ok()
+            .map(Cow::into_owned)
+    } else if template.contains('{') {
+        SimpleCurlyFormat
+            .format(template, args)
+            .ok()
+            .map(Cow::into_owned)
+    } else {
+        None
+    }
+}
+
+struct ParamArgs<'a>(&'a Value);
+
+impl FormatArgs for ParamArgs<'_> {
+    fn get_index(&self, index: usize) -> Result<Option<Argument<'_>>, ()> {
+        match self.0 {
+            Value::Array(array) => Ok(array.get(index).map(|v| v as Argument<'_>)),
+            _ => Err(()),
         }
     }
 
-    // Fallback to message (deprecated)
-    if let Some(message) = event_data.get("message") {
-        if let Some(msg) = message.as_str() {
-            return Some(msg.lines().next().unwrap_or("").to_string());
+    fn get_key(&self, key: &str) -> Result<Option<Argument<'_>>, ()> {
+        match self.0 {
+            Value::Object(object) => Ok(object.get(key).map(|v| v as Argument<'_>)),
+            _ => Err(()),
         }
-        if let Some(msg) = message.get("message").and_then(|m| m.as_str()) {
-            return Some(msg.lines().next().unwrap_or("").to_string());
+    }
+}
+
+/// A top-level `message` is the legacy spelling of `logentry` and carries the
+/// same object shape, so both are read the same way.
+fn get_log_message(event_data: &Value, preference: MessagePreference) -> Option<String> {
+    let first_line = |msg: &str| msg.lines().next().unwrap_or("").to_string();
+
+    for key in ["logentry", "message"] {
+        let Some(entry) = event_data.get(key) else {
+            continue;
+        };
+
+        if let Some(msg) = entry.as_str() {
+            return Some(first_line(msg));
+        }
+
+        let field = |name: &str| entry.get(name).and_then(|m| m.as_str());
+        let picked = match preference {
+            MessagePreference::Grouping => field("message").or_else(|| field("formatted")),
+            MessagePreference::Title => {
+                if let Some(formatted) = field("formatted") {
+                    Some(formatted)
+                } else {
+                    let rendered = field("message")
+                        .zip(entry.get("params"))
+                        .and_then(|(template, params)| format_message(template, params));
+                    match rendered {
+                        Some(rendered) => return Some(first_line(&rendered)),
+                        None => field("message"),
+                    }
+                }
+            }
+        };
+
+        if let Some(msg) = picked {
+            return Some(first_line(msg));
         }
     }
 

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -835,6 +835,75 @@ async fn test_new_event_after_retention_purge_does_not_collide() {
 // =============================================================================
 
 #[actix_web::test]
+async fn test_digest_message_only_events_get_their_own_issue_and_title() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Elixir Warnings").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let ingest_dir = temp_dir.path();
+    let rate_limit_config = create_rate_limit_config();
+
+    for warning in ["Disk almost full", "Cache miss storm"] {
+        let event_id = Uuid::new_v4().to_string().replace("-", "");
+        let event_json = json!({
+            "event_id": &event_id,
+            "timestamp": Utc::now().timestamp() as f64,
+            "platform": "elixir",
+            "level": "warning",
+            "exception": [],
+            "fingerprint": ["{{ default }}"],
+            "transaction": null,
+            "message": { "formatted": warning, "message": null, "params": null }
+        });
+        let event_bytes = serde_json::to_vec(&event_json).unwrap();
+
+        store_event(ingest_dir, &event_id, &event_bytes)
+            .await
+            .expect("Failed to store event");
+
+        let metadata = EventMetadata {
+            event_id: event_id.clone(),
+            project_id: project.id,
+            ingested_at: Utc::now(),
+            remote_addr: None,
+        };
+
+        process_error_event(
+            &db.pool,
+            &metadata,
+            ingest_dir,
+            &rate_limit_config,
+            crate::common::null_sourcemap_provider(),
+        )
+        .await
+        .expect("Failed to process event");
+    }
+
+    let (issues, _) = IssueService::list_paginated(
+        &db.pool,
+        project.id,
+        rustrak::pagination::IssueSort::DigestOrder,
+        rustrak::pagination::SortOrder::Desc,
+        true,
+        None,
+        100,
+    )
+    .await
+    .expect("Failed to list issues");
+
+    assert_eq!(issues.len(), 2, "the two warnings collapsed into one issue");
+
+    let mut titles: Vec<String> = issues.iter().map(|i| i.title()).collect();
+    titles.sort();
+    assert_eq!(
+        titles,
+        vec![
+            "Log Message: Cache miss storm".to_string(),
+            "Log Message: Disk almost full".to_string(),
+        ]
+    );
+}
+
+#[actix_web::test]
 async fn test_digest_groups_log_messages() {
     let db = TestDb::new().await;
     let project = create_test_project(&db.pool, "Log Message Project").await;

--- a/apps/server/tests/unit/grouping_test.rs
+++ b/apps/server/tests/unit/grouping_test.rs
@@ -198,6 +198,42 @@ fn test_grouping_prefers_message_over_formatted() {
 }
 
 #[test]
+fn test_an_empty_formatted_falls_through_to_the_message() {
+    // Sentry reads `formatted or message`, and an empty string is falsy there,
+    // so it must not shadow a usable template.
+    let event = json!({
+        "logentry": { "formatted": "", "message": "User %s logged in" }
+    });
+
+    let (type_, value) = get_type_and_value(&event);
+    assert_eq!(type_, "Log Message");
+    assert_eq!(value, "User %s logged in");
+}
+
+#[test]
+fn test_an_empty_message_falls_through_to_formatted_for_grouping() {
+    // The same falsy rule on the grouping side: `message or formatted`.
+    let event = json!({
+        "logentry": { "message": "", "formatted": "User john logged in" }
+    });
+
+    let key = calculate_grouping_key(&event);
+    assert!(key.contains("User john logged in"), "got {key}");
+}
+
+#[test]
+fn test_an_empty_message_object_still_falls_back() {
+    let event = json!({
+        "message": { "formatted": "", "message": "", "params": null },
+        "exception": []
+    });
+
+    let (type_, value) = get_type_and_value(&event);
+    assert_eq!(type_, "Unknown");
+    assert_eq!(value, "");
+}
+
+#[test]
 fn test_title_prefers_formatted_over_message() {
     let event = json!({
         "logentry": {

--- a/apps/server/tests/unit/grouping_test.rs
+++ b/apps/server/tests/unit/grouping_test.rs
@@ -161,7 +161,8 @@ fn test_logentry_message() {
 
     let (type_, value) = get_type_and_value(&event);
     assert_eq!(type_, "Log Message");
-    assert_eq!(value, "User %s logged in");
+    assert_eq!(value, "User john logged in");
+    assert!(calculate_grouping_key(&event).contains("User %s logged in"));
 }
 
 #[test]
@@ -178,7 +179,26 @@ fn test_logentry_formatted() {
 }
 
 #[test]
-fn test_logentry_prefers_message_over_formatted() {
+fn test_grouping_prefers_message_over_formatted() {
+    let john = json!({
+        "logentry": {
+            "message": "User %s logged in",
+            "formatted": "User john logged in"
+        }
+    });
+    let jane = json!({
+        "logentry": {
+            "message": "User %s logged in",
+            "formatted": "User jane logged in"
+        }
+    });
+
+    assert_eq!(calculate_grouping_key(&john), calculate_grouping_key(&jane));
+    assert!(calculate_grouping_key(&john).contains("User %s logged in"));
+}
+
+#[test]
+fn test_title_prefers_formatted_over_message() {
     let event = json!({
         "logentry": {
             "message": "User %s logged in",
@@ -186,9 +206,76 @@ fn test_logentry_prefers_message_over_formatted() {
         }
     });
 
+    let (type_, value) = get_type_and_value(&event);
+    assert_eq!(
+        get_title(&type_, &value),
+        "Log Message: User john logged in"
+    );
+}
+
+#[test]
+fn test_title_prefers_formatted_in_deprecated_message_object() {
+    let event = json!({
+        "message": {
+            "message": "User %s logged in",
+            "formatted": "User john logged in"
+        }
+    });
+
     let (_type, value) = get_type_and_value(&event);
-    // Should prefer 'message' (parameterized) for grouping
+    assert_eq!(value, "User john logged in");
+}
+
+#[test]
+fn test_title_interpolates_positional_params() {
+    let event = json!({
+        "logentry": {
+            "message": "User %s logged in",
+            "params": ["john"]
+        }
+    });
+
+    let (_type, value) = get_type_and_value(&event);
+    assert_eq!(value, "User john logged in");
+}
+
+#[test]
+fn test_title_interpolates_named_params() {
+    let event = json!({
+        "logentry": {
+            "message": "Hello, {name}!",
+            "params": { "name": "World" }
+        }
+    });
+
+    let (_type, value) = get_type_and_value(&event);
+    assert_eq!(value, "Hello, World!");
+}
+
+#[test]
+fn test_title_keeps_template_when_params_do_not_fit() {
+    let event = json!({
+        "logentry": {
+            "message": "User %s logged in",
+            "params": null
+        }
+    });
+
+    let (_type, value) = get_type_and_value(&event);
     assert_eq!(value, "User %s logged in");
+}
+
+#[test]
+fn test_title_leaves_a_literal_percent_alone() {
+    let event = json!({
+        "logentry": {
+            "message": "Disk 90% full",
+            "params": ["ignored"]
+        }
+    });
+
+    let (_type, value) = get_type_and_value(&event);
+    assert_eq!(value, "Disk 90% full");
 }
 
 #[test]
@@ -213,6 +300,29 @@ fn test_deprecated_message_object() {
     let (type_, value) = get_type_and_value(&event);
     assert_eq!(type_, "Log Message");
     assert_eq!(value, "Nested message");
+}
+
+#[test]
+fn test_deprecated_message_object_formatted() {
+    let event = json!({
+        "message": {
+            "formatted": "Nested formatted message",
+            "message": null,
+            "params": null
+        }
+    });
+
+    let (type_, value) = get_type_and_value(&event);
+    assert_eq!(type_, "Log Message");
+    assert_eq!(value, "Nested formatted message");
+}
+
+#[test]
+fn test_message_only_events_do_not_all_group_together() {
+    let foo = json!({ "message": { "formatted": "foo" } });
+    let bar = json!({ "message": { "formatted": "bar" } });
+
+    assert_ne!(calculate_grouping_key(&foo), calculate_grouping_key(&bar));
 }
 
 #[test]


### PR DESCRIPTION
Closes #301.

Thanks to @adriankumpf for the report. It was exact: the branch was missing, the file:line pointers were right, and the secondary note about titles was right too.

## What was wrong

A top-level `message` is the legacy spelling of `logentry` and carries the same object shape, but `get_log_message` only read `message.message`. Any SDK that renders a message before sending it hit this. sentry-elixir 13.5 is one: `build_message_interface/2` only fills `message` and `params` when the caller passes `:interpolation_parameters`, so a plain `Logger.warning/1` arrives as `{"message": {"formatted": "...", "message": null, "params": null}}`.

That returned nothing, the empty `exception` array was walked past, and the event fell to the `("Unknown", "")` fallback. Two consequences: the title became `Unknown`, and every message-only event in a project collapsed into one issue.

## What changed

**The missing branch.** `logentry` and `message` are now read through one path instead of two that had drifted apart.

**Title and grouping split.** They need opposite halves of `logentry`. Grouping takes the template, so every rendering of it lands in one issue. The title takes the rendered text, so a human reads real values. They are now derived independently from the same event.

No column or migration changes. The grouping key is only ever computed from the raw payload at digest time and is never reconstructed from the stored fields, so existing groups cannot desync. Issues already titled `Unknown` stay as they are; new events create proper issues.

**Interpolation.** When an SDK sends a template and params but no `formatted`, the title now renders it. This uses `dynfmt` with the same `python` and `curly` features Relay uses, so the formatting edge cases match. Version `0.2` rather than the `0.1` Relay pins, because `0.1` pulls in `thiserror 1.x` next to this repo's `2.0.20`; `0.2` drops it. Binary cost, measured on the release profile: **+146 KiB, +0.88%** (16.08 → 16.23 MiB).

When the params do not fit the template, the template is kept.

## Tests

Written first, each failure observed before the fix. Three tests in this repo asserted grouping intent through the title accessor and broke on the split; all three now assert both sides explicitly. That conflation was the deeper reason the bug survived.

The integration test was verified by reverting the fix and watching it report 1 issue instead of 2.

Also checked on a running server with real envelopes over HTTP:

```
events=2  title='Log Message: User john logged in'   value='User john logged in'
events=1  title='Log Message: Cache miss storm'      value='Cache miss storm'
events=1  title='Log Message: Disk almost full'      value='Disk almost full'
```

Two unrelated warnings get their own issues. Two renderings of one template share an issue and show the rendered text. No `Unknown`.

1066 tests green, `cargo fmt` and `cargo clippy --all-targets` clean.

## Follow-up

#302, opened from something noticed while testing this: an issue keeps the title, level and culprit of its first event forever, where Sentry updates them on every later event. Separate problem, separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log event grouping so messages with the same template are grouped consistently while retaining distinct formatted values.
  - Log titles now prioritize formatted messages and support positional and named parameter interpolation.
  - Message-only events are correctly separated into distinct issues.
  - Improved handling of legacy message formats, literal percent signs, and incomplete formatting parameters.
  - Empty message fields now correctly fall back to available values instead of obscuring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->