### PR TITLE
fix(server): let an issue's title, level and culprit follow the latest event

### DIFF
--- a/apps/server/src/digest/processors/event.rs
+++ b/apps/server/src/digest/processors/event.rs
@@ -602,30 +602,50 @@ async fn find_or_create_issue_and_grouping_inner(
         // reopen it as `regressed` (mirrors Sentry's lifecycle) — unless the
         // issue was "resolved in next release" and this event is still from the
         // same release (no new deploy yet), in which case it stays resolved.
-        let prev: (String, String, String) =
-            sqlx::query_as("SELECT status, status_details, last_release FROM issues WHERE id = $1")
-                .bind(grouping.issue_id)
-                .fetch_one(&mut **tx)
-                .await?;
-        let in_next_release = serde_json::from_str::<serde_json::Value>(&prev.1)
+        let prev: PrevIssue = sqlx::query_as(
+            "SELECT status, status_details, last_release, calculated_type, calculated_value, \
+             first_seen, last_seen FROM issues WHERE id = $1",
+        )
+        .bind(grouping.issue_id)
+        .fetch_one(&mut **tx)
+        .await?;
+        let in_next_release = serde_json::from_str::<serde_json::Value>(&prev.status_details)
             .ok()
             .and_then(|v| v.get("in_next_release").and_then(|b| b.as_bool()))
             .unwrap_or(false);
         // An event with no release metadata can't prove it's from a newer
         // release, so treat it as the same release rather than triggering a
         // spurious regression reopen.
-        let same_release = denormalized.release.is_empty() || denormalized.release == prev.2;
+        let same_release =
+            denormalized.release.is_empty() || denormalized.release == prev.last_release;
         let suppress = in_next_release && same_release;
-        let regressed = prev.0 == crate::models::STATUS_RESOLVED && !suppress;
+        let regressed = prev.status == crate::models::STATUS_RESOLVED && !suppress;
+
+        let (calculated_type, calculated_value) = updated_title(
+            (&prev.calculated_type, &prev.calculated_value),
+            (
+                &denormalized.calculated_type,
+                &denormalized.calculated_value,
+            ),
+        );
+        // An event can arrive older than the issue (clock skew across hosts, a
+        // replayed envelope), so each bound moves only in its own direction.
+        let first_seen = prev.first_seen.min(timestamp);
+        let last_seen = prev.last_seen.max(timestamp);
 
         // Grouping exists, update issue (reopening it if it regressed).
         let issue: Issue = if regressed {
             sqlx::query_as(
                 r#"
                 UPDATE issues
-                SET last_seen = $2,
+                SET first_seen = $8,
+                    last_seen = $2,
                     digested_event_count = digested_event_count + 1,
                     stored_event_count = stored_event_count + 1,
+                    calculated_type = $4,
+                    calculated_value = $5,
+                    level = $6,
+                    culprit = $7,
                     status = 'unresolved',
                     substatus = 'regressed',
                     status_details = '{}',
@@ -636,17 +656,27 @@ async fn find_or_create_issue_and_grouping_inner(
                 "#,
             )
             .bind(grouping.issue_id)
-            .bind(timestamp)
+            .bind(last_seen)
             .bind(&denormalized.release)
+            .bind(calculated_type)
+            .bind(calculated_value)
+            .bind(level)
+            .bind(&denormalized.culprit)
+            .bind(first_seen)
             .fetch_one(&mut **tx)
             .await?
         } else {
             sqlx::query_as(
                 r#"
                 UPDATE issues
-                SET last_seen = $2,
+                SET first_seen = $8,
+                    last_seen = $2,
                     digested_event_count = digested_event_count + 1,
                     stored_event_count = stored_event_count + 1,
+                    calculated_type = $4,
+                    calculated_value = $5,
+                    level = $6,
+                    culprit = $7,
                     last_release = CASE WHEN $3 <> '' THEN $3 ELSE last_release END,
                     first_release = CASE WHEN first_release = '' THEN $3 ELSE first_release END
                 WHERE id = $1
@@ -654,8 +684,13 @@ async fn find_or_create_issue_and_grouping_inner(
                 "#,
             )
             .bind(grouping.issue_id)
-            .bind(timestamp)
+            .bind(last_seen)
             .bind(&denormalized.release)
+            .bind(calculated_type)
+            .bind(calculated_value)
+            .bind(level)
+            .bind(&denormalized.culprit)
+            .bind(first_seen)
             .fetch_one(&mut **tx)
             .await?
         };
@@ -744,6 +779,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_real_incoming_title_always_wins() {
+        assert_eq!(
+            updated_title(("Log Message", "old"), ("TypeError", "boom")),
+            ("TypeError", "boom")
+        );
+        assert_eq!(
+            updated_title(("Unknown", ""), ("TypeError", "boom")),
+            ("TypeError", "boom")
+        );
+    }
+
+    #[test]
+    fn a_placeholder_incoming_title_loses_to_a_real_one() {
+        assert_eq!(
+            updated_title(("TypeError", "boom"), ("Unknown", "")),
+            ("TypeError", "boom")
+        );
+        assert_eq!(
+            updated_title(("TypeError", "boom"), ("Error", "")),
+            ("TypeError", "boom")
+        );
+    }
+
+    #[test]
+    fn a_placeholder_replaces_another_placeholder() {
+        assert_eq!(updated_title(("Unknown", ""), ("Error", "")), ("Error", ""));
+    }
+
+    #[test]
+    fn an_error_carrying_a_value_is_a_real_title() {
+        assert_eq!(
+            updated_title(("TypeError", "boom"), ("Error", "connection reset")),
+            ("Error", "connection reset")
+        );
+    }
+
+    #[test]
     fn busy_codes_are_recognized_and_others_are_not() {
         for code in ["5", "261", "517", "773"] {
             assert!(is_sqlite_busy_code(code), "{code} must classify as busy");
@@ -811,4 +883,38 @@ mod tests {
             "Invalid event JSON".to_string(),
         )));
     }
+}
+
+/// A title that says nothing about the event. Mirrors Sentry's
+/// `PLACEHOLDER_EVENT_TITLES` in Rustrak's vocabulary: "Unknown" is what an
+/// event with neither exception nor message produces, "Error" an exception
+/// carrying neither type nor value.
+fn is_placeholder_title(calculated_type: &str, calculated_value: &str) -> bool {
+    calculated_value.trim().is_empty() && matches!(calculated_type, "Unknown" | "Error")
+}
+
+/// Picks the type and value an issue should carry after a new event. The
+/// incoming pair wins unless it is a placeholder about to replace a real title.
+fn updated_title<'a>(
+    existing: (&'a str, &'a str),
+    incoming: (&'a str, &'a str),
+) -> (&'a str, &'a str) {
+    if is_placeholder_title(incoming.0, incoming.1) && !is_placeholder_title(existing.0, existing.1)
+    {
+        existing
+    } else {
+        incoming
+    }
+}
+
+/// The issue columns the update path reads before deciding what to write.
+#[derive(sqlx::FromRow)]
+struct PrevIssue {
+    status: String,
+    status_details: String,
+    last_release: String,
+    calculated_type: String,
+    calculated_value: String,
+    first_seen: chrono::DateTime<Utc>,
+    last_seen: chrono::DateTime<Utc>,
 }

--- a/apps/server/tests/integration/digest_test.rs
+++ b/apps/server/tests/integration/digest_test.rs
@@ -831,6 +831,239 @@ async fn test_new_event_after_retention_purge_does_not_collide() {
 }
 
 // =============================================================================
+// Issue Fields Follow the Latest Event
+// =============================================================================
+
+/// Digests one event into `project`, returning nothing; the caller reads the
+/// issue back. `event` is merged over the minimum an event needs.
+async fn digest(
+    pool: &rustrak::db::DbPool,
+    ingest_dir: &std::path::Path,
+    project_id: i32,
+    at: chrono::DateTime<Utc>,
+    mut event: serde_json::Value,
+) {
+    let event_id = Uuid::new_v4().to_string().replace("-", "");
+    let obj = event.as_object_mut().unwrap();
+    obj.insert("event_id".into(), json!(&event_id));
+    obj.insert("timestamp".into(), json!(at.timestamp() as f64));
+
+    store_event(ingest_dir, &event_id, &serde_json::to_vec(&event).unwrap())
+        .await
+        .expect("Failed to store event");
+
+    process_error_event(
+        pool,
+        &EventMetadata {
+            event_id,
+            project_id,
+            ingested_at: at,
+            remote_addr: None,
+        },
+        ingest_dir,
+        &create_rate_limit_config(),
+        crate::common::null_sourcemap_provider(),
+    )
+    .await
+    .expect("Failed to process event");
+}
+
+async fn only_issue(pool: &rustrak::db::DbPool, project_id: i32) -> rustrak::models::Issue {
+    let (issues, _) = IssueService::list_paginated(
+        pool,
+        project_id,
+        rustrak::pagination::IssueSort::DigestOrder,
+        rustrak::pagination::SortOrder::Desc,
+        true,
+        None,
+        100,
+    )
+    .await
+    .expect("Failed to list issues");
+    assert_eq!(issues.len(), 1, "expected the events to share one issue");
+    issues.into_iter().next().unwrap()
+}
+
+#[actix_web::test]
+async fn test_issue_title_follows_the_latest_event() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Title Follows").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = temp_dir.path();
+    let now = Utc::now();
+
+    let event = |param: &str| {
+        json!({
+            "platform": "elixir",
+            "level": "warning",
+            "logentry": { "message": "User %s logged in", "params": [param] }
+        })
+    };
+
+    digest(&db.pool, dir, project.id, now, event("john")).await;
+    digest(&db.pool, dir, project.id, now, event("jane")).await;
+
+    let issue = only_issue(&db.pool, project.id).await;
+    assert_eq!(issue.digested_event_count, 2);
+    assert_eq!(issue.title(), "Log Message: User jane logged in");
+}
+
+#[actix_web::test]
+async fn test_placeholder_title_does_not_overwrite_a_real_one() {
+    // Sentry keeps the existing title when the incoming one is a placeholder
+    // (`_get_updated_group_title`). Rustrak's placeholders are "Unknown", for an
+    // event with neither exception nor message, and a bare "Error".
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Placeholder Title").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = temp_dir.path();
+    let now = Utc::now();
+
+    // A custom fingerprint pins both events to one issue regardless of content.
+    let real = json!({
+        "platform": "rust",
+        "fingerprint": ["pinned"],
+        "logentry": { "formatted": "Something specific happened" }
+    });
+    let placeholder = json!({
+        "platform": "rust",
+        "fingerprint": ["pinned"]
+    });
+
+    digest(&db.pool, dir, project.id, now, real).await;
+    digest(&db.pool, dir, project.id, now, placeholder).await;
+
+    let issue = only_issue(&db.pool, project.id).await;
+    assert_eq!(issue.digested_event_count, 2);
+    assert_eq!(issue.title(), "Log Message: Something specific happened");
+}
+
+#[actix_web::test]
+async fn test_issue_level_and_culprit_follow_the_latest_event() {
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Level Follows").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = temp_dir.path();
+    let now = Utc::now();
+
+    let event = |level: &str, function: &str| {
+        json!({
+            "platform": "rust",
+            "level": level,
+            "fingerprint": ["pinned"],
+            "exception": { "values": [{
+                "type": "TypeError",
+                "value": "boom",
+                "stacktrace": { "frames": [{
+                    "filename": "app.rs", "function": function, "in_app": true
+                }]}
+            }]}
+        })
+    };
+
+    digest(
+        &db.pool,
+        dir,
+        project.id,
+        now,
+        event("warning", "first_path"),
+    )
+    .await;
+    digest(
+        &db.pool,
+        dir,
+        project.id,
+        now,
+        event("error", "second_path"),
+    )
+    .await;
+
+    let issue = only_issue(&db.pool, project.id).await;
+    assert_eq!(issue.level.as_deref(), Some("error"));
+    assert_eq!(issue.culprit, "second_path");
+}
+
+#[actix_web::test]
+async fn test_issue_keeps_creation_only_fields_across_events() {
+    // Sentry's `_process_existing_aggregate` never touches platform, logger or
+    // first_release, and sets priority only at creation.
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "Creation Only").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = temp_dir.path();
+    let now = Utc::now();
+
+    digest(
+        &db.pool,
+        dir,
+        project.id,
+        now,
+        json!({
+            "platform": "rust", "level": "warning", "logger": "first.logger",
+            "release": "1.0.0", "fingerprint": ["pinned"],
+            "logentry": { "formatted": "boom" }
+        }),
+    )
+    .await;
+    digest(
+        &db.pool,
+        dir,
+        project.id,
+        now,
+        json!({
+            "platform": "python", "level": "fatal", "logger": "second.logger",
+            "release": "2.0.0", "fingerprint": ["pinned"],
+            "logentry": { "formatted": "boom" }
+        }),
+    )
+    .await;
+
+    let issue = only_issue(&db.pool, project.id).await;
+    assert_eq!(issue.platform.as_deref(), Some("rust"));
+    assert_eq!(issue.logger, "first.logger");
+    assert_eq!(issue.first_release, "1.0.0");
+    assert_eq!(issue.last_release, "2.0.0");
+    assert_eq!(
+        issue.priority.as_deref(),
+        Some("medium"),
+        "priority is derived once, at creation"
+    );
+}
+
+#[actix_web::test]
+async fn test_first_seen_moves_back_for_an_older_event() {
+    // Clock skew between hosts, or a retried envelope, can deliver an event
+    // older than the issue. Sentry moves `first_seen` back; `last_seen` only
+    // ever moves forward.
+    let db = TestDb::new().await;
+    let project = create_test_project(&db.pool, "First Seen").await;
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = temp_dir.path();
+
+    let now = Utc::now();
+    let earlier = now - chrono::Duration::hours(2);
+    let event = json!({
+        "platform": "rust",
+        "logentry": { "formatted": "boom" }
+    });
+
+    digest(&db.pool, dir, project.id, now, event.clone()).await;
+    digest(&db.pool, dir, project.id, earlier, event).await;
+
+    let issue = only_issue(&db.pool, project.id).await;
+    assert!(
+        (issue.first_seen - earlier).num_seconds().abs() <= 1,
+        "first_seen should move back to the older event, got {}",
+        issue.first_seen
+    );
+    assert!(
+        (issue.last_seen - now).num_seconds().abs() <= 1,
+        "last_seen should stay at the newest event, got {}",
+        issue.last_seen
+    );
+}
+
+// =============================================================================
 // Log Message Grouping Tests
 // =============================================================================
 


### PR DESCRIPTION
Closes #302. Targets `AbianS/logentry-title-and-grouping-parity` (#303), not `main`, because it builds on it.

## What was wrong

An event joining an existing issue only bumped the counters and the timestamps. Both UPDATE branches in `find_or_create_issue_and_grouping_inner` left `calculated_type`, `calculated_value`, `level` and `culprit` at whatever the first event carried.

Sentry updates them on every event. `_process_existing_aggregate` (`src/sentry/event_manager.py:1889-1952`) writes `message`, `level`, `culprit`, `first_seen` and the merged `data` / `data["metadata"]`, so the issue follows the newest event.

Barely visible for exceptions, since the type and value are near-identical across a group by construction. It shows where a group legitimately holds different events: parameterized messages with different params, and custom fingerprints.

`level` drifts in any group, and an issue escalating from `warning` to `error` kept showing `warning`.

## What changed

Title, level and culprit now follow the newest event, with Sentry's guard on the title: a placeholder never replaces a real one. Sentry's `PLACEHOLDER_EVENT_TITLES` includes a bare `"Error"`, so the Rustrak equivalents are `"Unknown"` and `"Error"`, and only with an empty value. `Error: connection reset` is a real title.

Creation-only fields stay creation-only, which is also what Sentry does: platform, logger, first_release, and priority. Sentry derives priority once and moves it later through issue lifecycle, never per event. There is a test pinning this, because copying the whole incoming bag is the obvious wrong implementation.

## A second bug the tests found

`last_seen` was set unconditionally, so an event arriving out of order moved it **backwards**. Sentry has `last_seen = max(event.datetime, group.last_seen)`. This was not in #302; the `first_seen` test caught it because it asserted both bounds.

Both bounds are now computed in Rust rather than SQL: SQLite has two argument `min`/`max`, Postgres has `LEAST`/`GREATEST`, and there is no shared spelling.

Also refactored the `prev.0` / `prev.1` / `prev.2` tuple into a named struct while adding the columns it now needs.

## Deliberately not included

`last_frame_filename`, `last_frame_module` and `last_frame_function` are written to `issues` and never read back anywhere. Sentry's metadata merge does carry its equivalents forward, but updating a column nothing reads is noise, not parity. Noted in #304 along with the rest.

## Tests

Written first, each failure observed before the fix. Five integration tests over the digest path, four unit tests covering the placeholder truth table.

The unit tests were written after the code they cover, so they were checked by mutation: inverting the guard, and dropping the empty-value condition, each fails exactly one test.

Ran against a **real Postgres** through testcontainers, since this is SQL plus a new `FromRow` over `TIMESTAMPTZ` columns and CI runs no Postgres tests. 50/50 digest tests green there.

Two unrelated Postgres failures exist on this branch and on its base: `alerts_api_test.rs:958` calls SQLite's `datetime()` and `rate_limit_test.rs:609` uses SQLite trigger syntax, both in test scaffolding. Confirmed pre-existing by stashing this diff and re-running them alone. Worth a separate cleanup.

Checked on a running server with real envelopes:

```
after event 1  events=1  title='Log Message: User john logged in'  level='warning'
after event 2  events=2  title='Log Message: User jane logged in'  level='error'
```

1075 tests green, `cargo fmt` and `cargo clippy --all-targets` clean.

## Follow-up

#304 lists four thinner spots in the issue model found along the way: no `active_at`, issue search covering only the title, `main_exception_id` ignored, and no `location`.

One correction worth recording there: I first assumed the missing `active_at` meant Rustrak could double-fire regression alerts, since Sentry uses it as a 5 second debounce. It cannot. Rustrak reads and writes the status inside one transaction under `BEGIN IMMEDIATE` or a per-project advisory lock, so the second event already sees `unresolved`. Checked with a throwaway test before writing the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Issue details now stay synchronized with the latest event, including title, severity level, culprit, and calculated values.
  - Issue timestamps now accurately track both the earliest and latest events.
  - Placeholder titles no longer replace meaningful titles.
  - Original creation details, such as platform, logger, first release, and priority, remain preserved when new events are received.
- **Tests**
  - Added coverage for updating issue fields and maintaining timestamp and creation-field behavior across grouped events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->