### PR TITLE
Fix NaN span durations for RFC 3339 timestamps

### DIFF
--- a/.changeset/fuzzy-spans-smile.md
+++ b/.changeset/fuzzy-spans-smile.md
@@ -1,0 +1,7 @@
+---
+"webview-ui": patch
+---
+
+Normalize numeric and RFC3339 timestamps on transaction-embedded spans before
+rendering the performance waterfall. This prevents Sentry SDKs that emit mixed
+timestamp representations from displaying `NaN` duration and self-time values.

--- a/.changeset/fuzzy-spans-smile.md
+++ b/.changeset/fuzzy-spans-smile.md
@@ -1,7 +1,0 @@
----
-"webview-ui": patch
----
-
-Normalize numeric and RFC3339 timestamps on transaction-embedded spans before
-rendering the performance waterfall. This prevents Sentry SDKs that emit mixed
-timestamp representations from displaying `NaN` duration and self-time values.

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
@@ -103,6 +103,74 @@ describe('readTransactionPayload', () => {
     ]);
   });
 
+  // Captured from sentry-types 0.49.2, which serializes a span's two ends with
+  // different encodings: ts_seconds_float and ts_rfc3339_opt.
+  it('reads a real Rust-SDK span into arithmetic that yields a duration', () => {
+    const payload = readTransactionPayload(
+      txn({
+        timestamp: '2025-09-04T15:33:20.800Z',
+        start_timestamp: '2025-09-04T15:33:20.500Z',
+        data: {
+          start_timestamp: 1757000000.5,
+          timestamp: '2025-09-04T15:33:20.8Z',
+          spans: [
+            {
+              op: 'db.sql.query',
+              span_id: 'f796eed91584d618',
+              start_timestamp: 1757000000.5,
+              timestamp: '2025-09-04T15:33:20.8Z',
+              trace_id: 'db542d8976bbdc31d5940a8bfe604128',
+            },
+          ],
+        },
+      }),
+    );
+
+    const [span] = payload.spans;
+    const durationMs =
+      ((span.timestamp as number) - (span.start_timestamp as number)) * 1000;
+
+    expect(durationMs).toBeCloseTo(300, 3);
+    // Math.max over a string is NaN, which takes the whole waterfall window.
+    expect(
+      Math.max(payload.transactionStart, span.timestamp as number),
+    ).not.toBeNaN();
+  });
+
+  it('reads a span timestamp with no offset as UTC, the way Relay does', () => {
+    const [span] = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              start_timestamp: 1757000000.5,
+              timestamp: '2025-09-04T15:33:20.8',
+            },
+          ],
+        },
+      }),
+    ).spans;
+
+    expect(span.timestamp).toBeCloseTo(1757000000.8, 3);
+  });
+
+  it('rejects date strings Relay would not have accepted', () => {
+    const [span] = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            // Date.parse turns both of these into a finite epoch.
+            { span_id: 's1', start_timestamp: '2025/09/04', timestamp: '0' },
+          ],
+        },
+      }),
+    ).spans;
+
+    expect(span.start_timestamp).toBeUndefined();
+    expect(span.timestamp).toBeUndefined();
+  });
+
   it('prefers the payload epoch seconds over the row timestamps', () => {
     const payload = readTransactionPayload(
       txn({ data: { start_timestamp: 1000, timestamp: 1002 } }),

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
@@ -55,6 +55,54 @@ describe('readTransactionPayload', () => {
     ).toEqual([]);
   });
 
+  it('normalizes mixed numeric and RFC3339 span timestamps', () => {
+    const payload = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              start_timestamp: 1000,
+              timestamp: '1970-01-01T00:16:42.000Z',
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(payload.spans).toEqual([
+      {
+        span_id: 's1',
+        start_timestamp: 1000,
+        timestamp: 1002,
+      },
+    ]);
+  });
+
+  it('drops invalid span timestamps instead of exposing NaN arithmetic', () => {
+    const payload = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              start_timestamp: Number.NaN,
+              timestamp: 'not-a-timestamp',
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(payload.spans).toEqual([
+      {
+        span_id: 's1',
+        start_timestamp: undefined,
+        timestamp: undefined,
+      },
+    ]);
+  });
+
   it('prefers the payload epoch seconds over the row timestamps', () => {
     const payload = readTransactionPayload(
       txn({ data: { start_timestamp: 1000, timestamp: 1002 } }),

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
@@ -213,6 +213,25 @@ describe('readTransactionPayload', () => {
     expect(span.timestamp).toBeUndefined();
   });
 
+  it('rejects hour 24, which Date.parse rolls into the next day', () => {
+    const [span] = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              start_timestamp: '2025-09-04T24:00:00Z',
+              timestamp: '2025-09-04T23:59:59Z',
+            },
+          ],
+        },
+      }),
+    ).spans;
+
+    expect(span.start_timestamp).toBeUndefined();
+    expect(span.timestamp).toBe(1757030399);
+  });
+
   it('prefers the payload epoch seconds over the row timestamps', () => {
     const payload = readTransactionPayload(
       txn({ data: { start_timestamp: 1000, timestamp: 1002 } }),

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.test.ts
@@ -171,6 +171,48 @@ describe('readTransactionPayload', () => {
     expect(span.timestamp).toBeUndefined();
   });
 
+  it('keeps microsecond precision so a sub-ms span is not negative', () => {
+    // Both ends are the same instant; the SDK just encodes them differently.
+    const [span] = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              start_timestamp: 1757000000.123456,
+              timestamp: '2025-09-04T15:33:20.123456Z',
+            },
+          ],
+        },
+      }),
+    ).spans;
+
+    expect(span.timestamp).toBe(1757000000.123456);
+    expect(
+      ((span.timestamp as number) - (span.start_timestamp as number)) * 1000,
+    ).toBe(0);
+  });
+
+  it('rejects calendar-impossible dates instead of rolling them forward', () => {
+    const [span] = readTransactionPayload(
+      txn({
+        data: {
+          spans: [
+            {
+              span_id: 's1',
+              // Date.parse turns these into March 2nd and March 1st.
+              start_timestamp: '2025-02-30T00:00:00Z',
+              timestamp: '2025-02-29T00:00:00Z',
+            },
+          ],
+        },
+      }),
+    ).spans;
+
+    expect(span.start_timestamp).toBeUndefined();
+    expect(span.timestamp).toBeUndefined();
+  });
+
   it('prefers the payload epoch seconds over the row timestamps', () => {
     const payload = readTransactionPayload(
       txn({ data: { start_timestamp: 1000, timestamp: 1002 } }),

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
@@ -10,9 +10,14 @@ function asObject(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
-/** The grammar Relay accepts for a timestamp string, and no more. */
+/**
+ * The grammar Relay accepts for a timestamp string, and no more.
+ *
+ * The hour is bounded because `Date.parse` treats `24:00:00` as midnight the
+ * next day, a whole day of drift on a value chrono rejects outright.
+ */
 const ISO_DATE_TIME =
-  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})?$/;
+  /^(\d{4})-(\d{2})-(\d{2})[T ]((?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d)(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})?$/;
 
 /** February 30th is a date `Date.parse` rolls into March and chrono rejects. */
 function isRealCalendarDate(year: number, month: number, day: number): boolean {

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
@@ -12,13 +12,29 @@ function asObject(value: unknown): Record<string, unknown> | null {
 
 /** The grammar Relay accepts for a timestamp string, and no more. */
 const ISO_DATE_TIME =
-  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2}(?:\.\d+)?)(Z|[+-]\d{2}:?\d{2})?$/;
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})?$/;
+
+/** February 30th is a date `Date.parse` rolls into March and chrono rejects. */
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+  const probe = new Date(0);
+  probe.setUTCFullYear(year, month - 1, day);
+  return (
+    probe.getUTCFullYear() === year &&
+    probe.getUTCMonth() === month - 1 &&
+    probe.getUTCDate() === day
+  );
+}
 
 /**
  * A moment on the waterfall's clock, which counts seconds.
  *
  * No offset means UTC, as it does in Relay. `Date.parse` would read it as the
  * reader's local time and place the same span differently in every timezone.
+ *
+ * The fraction is added back by hand because `Date.parse` truncates it to
+ * milliseconds, and the SDK sends microseconds: against a full-precision
+ * `start_timestamp` float that truncation renders sub-millisecond spans with a
+ * negative duration.
  */
 function parseEpochSeconds(raw: unknown): number | undefined {
   if (typeof raw === 'number') {
@@ -29,9 +45,17 @@ function parseEpochSeconds(raw: unknown): number | undefined {
   const match = ISO_DATE_TIME.exec(raw);
   if (!match) return undefined;
 
-  const [, date, time, offset] = match;
-  const milliseconds = Date.parse(`${date}T${time}${offset ?? 'Z'}`);
-  return Number.isFinite(milliseconds) ? milliseconds / 1000 : undefined;
+  const [, year, month, day, time, fraction, offset] = match;
+  if (!isRealCalendarDate(Number(year), Number(month), Number(day))) {
+    return undefined;
+  }
+
+  const milliseconds = Date.parse(
+    `${year}-${month}-${day}T${time}${offset ?? 'Z'}`,
+  );
+  if (!Number.isFinite(milliseconds)) return undefined;
+
+  return milliseconds / 1000 + (fraction ? Number(`0.${fraction}`) : 0);
 }
 
 /**

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
@@ -10,6 +10,30 @@ function asObject(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
+/** The grammar Relay accepts for a timestamp string, and no more. */
+const ISO_DATE_TIME =
+  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2}(?:\.\d+)?)(Z|[+-]\d{2}:?\d{2})?$/;
+
+/**
+ * A moment on the waterfall's clock, which counts seconds.
+ *
+ * No offset means UTC, as it does in Relay. `Date.parse` would read it as the
+ * reader's local time and place the same span differently in every timezone.
+ */
+function parseEpochSeconds(raw: unknown): number | undefined {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? raw : undefined;
+  }
+  if (typeof raw !== 'string') return undefined;
+
+  const match = ISO_DATE_TIME.exec(raw);
+  if (!match) return undefined;
+
+  const [, date, time, offset] = match;
+  const milliseconds = Date.parse(`${date}T${time}${offset ?? 'Z'}`);
+  return Number.isFinite(milliseconds) ? milliseconds / 1000 : undefined;
+}
+
 /**
  * A moment on the waterfall's clock, which counts seconds.
  *
@@ -17,17 +41,6 @@ function asObject(value: unknown): Record<string, unknown> | null {
  * The fallback has to be converted rather than passed through, or every bar
  * would be placed a thousand times too far along.
  */
-function parseEpochSeconds(raw: unknown): number | undefined {
-  if (typeof raw === 'number') {
-    return Number.isFinite(raw) ? raw : undefined;
-  }
-  if (typeof raw === 'string') {
-    const milliseconds = Date.parse(raw);
-    return Number.isFinite(milliseconds) ? milliseconds / 1000 : undefined;
-  }
-  return undefined;
-}
-
 function epochSeconds(raw: unknown, fallbackIso: string): number {
   return parseEpochSeconds(raw) ?? Date.parse(fallbackIso) / 1000;
 }

--- a/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
+++ b/apps/webview-ui/src/features/transaction/lib/transaction-payload.ts
@@ -17,9 +17,37 @@ function asObject(value: unknown): Record<string, unknown> | null {
  * The fallback has to be converted rather than passed through, or every bar
  * would be placed a thousand times too far along.
  */
+function parseEpochSeconds(raw: unknown): number | undefined {
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? raw : undefined;
+  }
+  if (typeof raw === 'string') {
+    const milliseconds = Date.parse(raw);
+    return Number.isFinite(milliseconds) ? milliseconds / 1000 : undefined;
+  }
+  return undefined;
+}
+
 function epochSeconds(raw: unknown, fallbackIso: string): number {
-  if (typeof raw === 'number') return raw;
-  return Date.parse(fallbackIso) / 1000;
+  return parseEpochSeconds(raw) ?? Date.parse(fallbackIso) / 1000;
+}
+
+/**
+ * Normalizes timestamps on a transaction-embedded span to epoch seconds.
+ *
+ * Sentry SDKs may encode protocol timestamps as either epoch numbers or
+ * RFC3339 strings. Keeping that distinction out of the waterfall prevents
+ * arithmetic on a string from producing `NaN` durations and geometry.
+ */
+function readSpan(raw: unknown): Span | null {
+  const span = asObject(raw);
+  if (!span) return null;
+
+  return {
+    ...span,
+    start_timestamp: parseEpochSeconds(span.start_timestamp),
+    timestamp: parseEpochSeconds(span.timestamp),
+  } as Span;
 }
 
 function asString(value: unknown): string | undefined {
@@ -57,7 +85,12 @@ export function readTransactionPayload(
 
   return {
     trace: trace as TraceContext | undefined,
-    spans: Array.isArray(data.spans) ? (data.spans as Span[]) : [],
+    spans: Array.isArray(data.spans)
+      ? data.spans.flatMap((span) => {
+          const normalized = readSpan(span);
+          return normalized ? [normalized] : [];
+        })
+      : [],
     measurements: asObject(data.measurements),
     tags: asObject(data.tags),
     request: asObject(data.request),

--- a/apps/webview-ui/src/features/transaction/model/span.ts
+++ b/apps/webview-ui/src/features/transaction/model/span.ts
@@ -13,7 +13,9 @@
  * neither slice imports the other, and neither type belongs in `shared`.
  *
  * Every field is optional because SDKs omit most of them. A minimal legal span
- * is `{ span_id, start_timestamp, timestamp }`.
+ * is `{ span_id, start_timestamp, timestamp }`. The transaction payload reader
+ * normalizes timestamps from either epoch numbers or RFC3339 strings before
+ * this type reaches the UI.
  */
 export interface Span {
   span_id?: string;


### PR DESCRIPTION
Summary

Normalize transaction span timestamps before they are used by the performance UI.

Sentry-compatible SDKs can encode span timestamps using mixed formats. For example, the Rust Sentry SDK emits the start timestamp as numeric epoch seconds and the end timestamp as an RFC 3339 string. Directly subtracting these values in JavaScript produces NaN, causing Rustrak to display NaNs for span duration and self time.

Changes

Accept numeric epoch-second and RFC 3339 span timestamps.

Normalize timestamps to epoch seconds when reading transaction payloads.

Treat missing or invalid timestamps as undefined instead of allowing NaN values into the UI.

Update the embedded span type documentation.

Add regression tests for mixed-format and invalid timestamps.

Add a patch changeset for webview-ui.

Validation

Focused transaction payload tests: 10 passed

TypeScript type checking: passed

Biome lint: passed

Biome formatting check: passed

This keeps timestamp handling at the transaction payload boundary so downstream performance components continue working with consistently normalized values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction span timestamp handling for numeric and RFC3339 formats.
  * Preserved fractional-second precision beyond milliseconds.
  * Prevented invalid, loosely formatted, or calendar-impossible timestamps from producing incorrect durations or calculation errors.
  * Standardized timestamps without offsets as UTC.
  * Excluded malformed span entries from transaction details.

* **Documentation**
  * Clarified how transaction timestamps are normalized before display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->