### PR TITLE
feat(webview-ui): allow configuring exposed host without port mapping

### DIFF
--- a/apps/docs/content/configuration/environment.mdx
+++ b/apps/docs/content/configuration/environment.mdx
@@ -192,7 +192,37 @@ Only creates user if database is empty.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RUSTRAK_API_URL` | `http://localhost:8080` | Backend API URL |
+| `HOSTNAME` | `0.0.0.0` | Bind address for the dashboard (Next.js standalone) |
+| `HOST` | `0.0.0.0` | Alias for `HOSTNAME` |
+| `PORT` | `3000` | Port the dashboard listens on **inside** the container |
 | `RUSTRAK_VERSION_CHECK_ENABLED` | `true` | Set to `false` to disable the update notice and stop all outbound version checks |
+
+### HOSTNAME / PORT (dashboard)
+
+The dashboard is a Next.js standalone server. It reads `HOSTNAME` and `PORT` at runtime:
+
+```bash
+# Inside Docker (default — correct)
+HOSTNAME=0.0.0.0
+PORT=3000
+```
+
+`HOST` is accepted as an alias for `HOSTNAME` for compatibility with the typical Docker convention — if `HOSTNAME` is unset, `HOST` is used.
+
+> **Behind a reverse proxy?** You don't need to expose a host port. Remove the `ports` section from the `ui` service in `docker-compose.yml` and let the proxy (Traefik, nginx, Caddy) route by host header. The container still listens on `3000` internally, but nothing is mapped to the host.
+>
+> ```yaml
+> # docker-compose.yml — no ports, routed by host via proxy network
+> services:
+>   ui:
+>     image: rustrak/rustrak-ui:latest
+>     environment:
+>       - HOSTNAME=0.0.0.0
+>       - RUSTRAK_API_URL=http://server:8080
+>     networks: [proxy]
+> ```
+>
+> The same applies to the `server` service — combine with `PUBLIC_URL=https://your-domain.com` so the DSN shown in the dashboard uses your public host instead of `0.0.0.0:8080`.
 
 ### RUSTRAK_VERSION_CHECK_ENABLED
 
@@ -215,7 +245,6 @@ RUSTRAK_VERSION_CHECK_ENABLED=false
 With the check disabled, no request is made under any circumstances.
 
 ## Complete Example
-
 ### SQLite (development / personal)
 
 ```bash

--- a/apps/docs/content/configuration/environment.mdx
+++ b/apps/docs/content/configuration/environment.mdx
@@ -191,38 +191,51 @@ Only creates user if database is empty.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RUSTRAK_API_URL` | `http://localhost:8080` | Backend API URL |
-| `HOSTNAME` | `0.0.0.0` | Bind address for the dashboard (Next.js standalone) |
-| `HOST` | `0.0.0.0` | Alias for `HOSTNAME` |
+| `RUSTRAK_API_URL` | `http://localhost:8080` | Address the dashboard uses to reach the server. Always an internal one |
 | `PORT` | `3000` | Port the dashboard listens on **inside** the container |
+| `HOSTNAME` | `0.0.0.0` | TCP bind address. Already correct in the image |
 | `RUSTRAK_VERSION_CHECK_ENABLED` | `true` | Set to `false` to disable the update notice and stop all outbound version checks |
 
-### HOSTNAME / PORT (dashboard)
+### RUSTRAK_API_URL
 
-The dashboard is a Next.js standalone server. It reads `HOSTNAME` and `PORT` at runtime:
+Every call the dashboard makes to the server happens **server-side**, inside the
+Next.js process. The browser never talks to the server directly, so this is the
+address one container uses to reach the other:
 
 ```bash
-# Inside Docker (default — correct)
-HOSTNAME=0.0.0.0
-PORT=3000
+# Docker Compose: the service name
+RUSTRAK_API_URL=http://server:8080
+
+# Dashboard running outside Docker
+RUSTRAK_API_URL=http://localhost:8080
 ```
 
-`HOST` is accepted as an alias for `HOSTNAME` for compatibility with the typical Docker convention — if `HOSTNAME` is unset, `HOST` is used.
+It stays internal even when both are published on a public domain. Pointing it
+at that domain sends the dashboard's own API calls back out through your proxy,
+which routes them to the dashboard rather than the server, and sign-in stops
+working.
 
-> **Behind a reverse proxy?** You don't need to expose a host port. Remove the `ports` section from the `ui` service in `docker-compose.yml` and let the proxy (Traefik, nginx, Caddy) route by host header. The container still listens on `3000` internally, but nothing is mapped to the host.
->
-> ```yaml
-> # docker-compose.yml — no ports, routed by host via proxy network
-> services:
->   ui:
->     image: rustrak/rustrak-ui:latest
->     environment:
->       - HOSTNAME=0.0.0.0
->       - RUSTRAK_API_URL=http://server:8080
->     networks: [proxy]
-> ```
->
-> The same applies to the `server` service — combine with `PUBLIC_URL=https://your-domain.com` so the DSN shown in the dashboard uses your public host instead of `0.0.0.0:8080`.
+### HOSTNAME
+
+The interface the dashboard binds to inside its container. The image already
+sets `0.0.0.0`, which is what you want in every deployment, so you do not need
+this in your Compose file or your `.env`.
+
+It is spelled `HOSTNAME` and not `HOST` because that is the name a Next.js
+standalone server reads. Docker also fills `HOSTNAME` with the container id on
+any image that leaves it unset, and that collision has one practical
+consequence: **never forward the ambient variable into the container**.
+
+```yaml
+# Wrong. On a host that exports HOSTNAME (a CI runner, Portainer, anything
+# running Compose from inside a container) the dashboard inherits a name it
+# cannot bind to and the container crash-loops on ENOTFOUND.
+environment:
+  - HOSTNAME=${HOSTNAME:-0.0.0.0}
+```
+
+> **Behind a reverse proxy?** You do not need to publish a host port for either
+> service. See [Reverse proxy](/configuration/production#reverse-proxy).
 
 ### RUSTRAK_VERSION_CHECK_ENABLED
 
@@ -245,6 +258,7 @@ RUSTRAK_VERSION_CHECK_ENABLED=false
 With the check disabled, no request is made under any circumstances.
 
 ## Complete Example
+
 ### SQLite (development / personal)
 
 ```bash

--- a/apps/docs/content/configuration/production.mdx
+++ b/apps/docs/content/configuration/production.mdx
@@ -20,28 +20,8 @@ openssl rand -base64 24
 
 ### 2. Use HTTPS
 
-Put Rustrak behind a reverse proxy with SSL:
-
-```nginx
-# nginx example
-server {
-    listen 443 ssl http2;
-    server_name rustrak.yourcompany.com;
-
-    ssl_certificate /etc/ssl/certs/rustrak.crt;
-    ssl_certificate_key /etc/ssl/private/rustrak.key;
-
-    location / {
-        proxy_pass http://localhost:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-```
-
-Or use Caddy, Traefik, or your cloud provider's load balancer.
+Put Rustrak behind a reverse proxy that terminates SSL. See
+[Reverse proxy](#reverse-proxy) below for the routing.
 
 ### 3. Enable SSL_PROXY
 
@@ -67,6 +47,117 @@ DATABASE_URL=postgres://user:pass@host:5432/rustrak?sslmode=require
 - Use strong passwords
 - Restrict network access
 - Enable automated backups
+
+## Reverse proxy
+
+Neither container needs a published host port. Put them on the proxy's network,
+delete the `ports:` blocks from `docker-compose.yml`, and let the proxy reach
+them on `3000` and `8080` directly.
+
+Two addresses decide the rest of the configuration, and they are not the same
+one:
+
+- **`RUSTRAK_API_URL` is internal.** The dashboard calls the server from inside
+  its own container, server-side, so this request never leaves the Docker
+  network. It stays `http://server:8080`.
+- **`PUBLIC_URL` is public.** It is the host Rustrak writes into every DSN, so
+  it has to be an address your SDKs can reach from outside.
+
+Getting the first one wrong is the common mistake: pointing `RUSTRAK_API_URL` at
+your public domain sends the dashboard's own calls back out through the proxy,
+which routes them to the dashboard instead of the server, and sign-in fails.
+
+### Two hostnames
+
+One host for the dashboard, one for ingestion. Nothing overlaps, so this is the
+shape to reach for.
+
+```yaml
+# docker-compose.yml
+services:
+  server:
+    image: rustrak/rustrak-server:latest
+    environment:
+      - DATABASE_URL=postgres://rustrak:${POSTGRES_PASSWORD}@postgres:5432/rustrak
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
+      - SSL_PROXY=true
+      - PUBLIC_URL=https://ingest.example.com
+    networks: [internal, proxy]
+
+  ui:
+    image: rustrak/rustrak-ui:latest
+    environment:
+      - RUSTRAK_API_URL=http://server:8080
+    networks: [proxy]
+
+networks:
+  internal:
+  proxy:
+    external: true
+```
+
+With nginx, that is one `server` block per hostname:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name rustrak.example.com;   # dashboard
+    location / {
+        proxy_pass http://ui:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ingest.example.com;    # SDKs and the DSN
+    location / {
+        proxy_pass http://server:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Caddy says the same thing in four lines, and Traefik in two labels per service
+(`traefik.http.routers.<name>.rule=Host(...)` plus the service port). The rule
+is the same in all three: hostname in, container out, no published port.
+
+### One hostname
+
+If you only have one name to spend, route by path. Everything an SDK sends
+lives under `/api/`, and the dashboard serves no routes there:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name rustrak.example.com;
+
+    location /api/ {
+        proxy_pass http://server:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://ui:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+`PUBLIC_URL=https://rustrak.example.com` then produces a DSN with no port in
+it, and the SDK's `POST /api/<project>/envelope/` lands on the server.
+
+The server's own `/auth/` and `/health/` routes are deliberately not exposed
+this way: the dashboard reaches them over `RUSTRAK_API_URL` on the internal
+network, and `/auth/login` on the public host is the dashboard's sign-in page.
 
 ## Performance
 

--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -57,13 +57,16 @@ services:
   server:
     image: rustrak/rustrak-server:postgres
     ports:
-      - "${SERVER_PORT}:8080"
+      - "${SERVER_PORT:-8080}:8080"
     environment:
+      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=${RUST_LOG}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
       - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+      # Set to your public host to avoid exposing :8080 in DSN (e.g. https://rustrak.example.com)
+      - PUBLIC_URL=${PUBLIC_URL:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -72,8 +75,9 @@ services:
   ui:
     image: rustrak/rustrak-ui:latest
     ports:
-      - "${UI_PORT}:3000"
+      - "${UI_PORT:-3000}:3000"
     environment:
+      - HOSTNAME=${HOSTNAME:-0.0.0.0}
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
     depends_on:
       - server
@@ -84,7 +88,6 @@ volumes:
 ```
 
 **What each service does:**
-
 | Service | Description |
 |---------|-------------|
 | `postgres` | PostgreSQL 16 database with persistent storage. Includes a healthcheck to ensure it's ready before the server starts. |
@@ -107,7 +110,11 @@ POSTGRES_DB=rustrak
 # Server
 # ===================
 SERVER_PORT=8080
+HOST=0.0.0.0
 RUST_LOG=info
+# Public host for DSN — set when behind a reverse proxy to hide the port
+# e.g. PUBLIC_URL=https://rustrak.example.com
+PUBLIC_URL=
 
 # Session secret (required) - replace with the output of: openssl rand -hex 32
 # The server refuses to start until you do.
@@ -120,8 +127,11 @@ CREATE_SUPERUSER=admin@example.com:changeme123
 # Dashboard
 # ===================
 UI_PORT=3000
+HOSTNAME=0.0.0.0
 RUSTRAK_API_URL=http://server:8080
 ```
+
+> **Reverse proxy (no port exposure):** If you run behind Traefik / nginx / Caddy, you can remove the `ports` section from `server` and `ui` and route by host header instead. Keep `HOST`/`HOSTNAME=0.0.0.0` inside the container and set `PUBLIC_URL=https://your-domain.com` + `RUSTRAK_API_URL=https://your-domain.com` so the DSN and dashboard use the public host without a port.
 
 To generate a secure session secret:
 

--- a/apps/docs/content/getting-started/installation.mdx
+++ b/apps/docs/content/getting-started/installation.mdx
@@ -59,13 +59,11 @@ services:
     ports:
       - "${SERVER_PORT:-8080}:8080"
     environment:
-      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=${RUST_LOG}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
       - CREATE_SUPERUSER=${CREATE_SUPERUSER}
-      # Set to your public host to avoid exposing :8080 in DSN (e.g. https://rustrak.example.com)
       - PUBLIC_URL=${PUBLIC_URL:-}
     depends_on:
       postgres:
@@ -77,7 +75,6 @@ services:
     ports:
       - "${UI_PORT:-3000}:3000"
     environment:
-      - HOSTNAME=${HOSTNAME:-0.0.0.0}
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
     depends_on:
       - server
@@ -88,6 +85,7 @@ volumes:
 ```
 
 **What each service does:**
+
 | Service | Description |
 |---------|-------------|
 | `postgres` | PostgreSQL 16 database with persistent storage. Includes a healthcheck to ensure it's ready before the server starts. |
@@ -110,10 +108,9 @@ POSTGRES_DB=rustrak
 # Server
 # ===================
 SERVER_PORT=8080
-HOST=0.0.0.0
 RUST_LOG=info
-# Public host for DSN — set when behind a reverse proxy to hide the port
-# e.g. PUBLIC_URL=https://rustrak.example.com
+# The address your SDKs will send events to. Without it the DSN carries the
+# bind address, which nothing can reach. e.g. https://rustrak.example.com
 PUBLIC_URL=
 
 # Session secret (required) - replace with the output of: openssl rand -hex 32
@@ -127,11 +124,16 @@ CREATE_SUPERUSER=admin@example.com:changeme123
 # Dashboard
 # ===================
 UI_PORT=3000
-HOSTNAME=0.0.0.0
+# The dashboard reaches the server from inside its own container, so this is
+# the internal address and stays internal behind a proxy.
 RUSTRAK_API_URL=http://server:8080
 ```
 
-> **Reverse proxy (no port exposure):** If you run behind Traefik / nginx / Caddy, you can remove the `ports` section from `server` and `ui` and route by host header instead. Keep `HOST`/`HOSTNAME=0.0.0.0` inside the container and set `PUBLIC_URL=https://your-domain.com` + `RUSTRAK_API_URL=https://your-domain.com` so the DSN and dashboard use the public host without a port.
+> **Reverse proxy?** Behind Traefik, nginx or Caddy you can delete the `ports`
+> blocks from `server` and `ui` entirely and let the proxy reach the containers
+> on the Docker network. Set `PUBLIC_URL` to your public host and leave
+> `RUSTRAK_API_URL` internal. See
+> [Reverse proxy](/configuration/production#reverse-proxy).
 
 To generate a secure session secret:
 

--- a/apps/webview-ui/Dockerfile
+++ b/apps/webview-ui/Dockerfile
@@ -42,9 +42,19 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 USER nextjs
 
+# Next.js standalone reads HOSTNAME and PORT at runtime.
+# HOSTNAME controls the bind address; 0.0.0.0 is correct for Docker.
+# HOST is also accepted as alias via startup shell (HOST -> HOSTNAME fallback).
+ENV HOSTNAME="0.0.0.0"
+ENV PORT="3000"
+EXPOSE 3000
+
 # Copia sólo lo necesario para producción (standalone, static y public)
 COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/.next/static ./apps/webview-ui/.next/static
 COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/public ./apps/webview-ui/public
 
-CMD node apps/webview-ui/server.js
+# HOST is an alias for HOSTNAME (common convention). Next.js standalone only
+# reads HOSTNAME, so map HOST -> HOSTNAME when HOSTNAME is not explicitly set.
+# This allows `HOST=0.0.0.0` or reverse-proxy setups without exposing a port.
+CMD ["sh", "-c", "HOSTNAME=${HOSTNAME:-${HOST:-0.0.0.0}} PORT=${PORT:-3000} node apps/webview-ui/server.js"]

--- a/apps/webview-ui/Dockerfile
+++ b/apps/webview-ui/Dockerfile
@@ -42,9 +42,12 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 USER nextjs
 
-# Next.js standalone reads HOSTNAME and PORT at runtime.
-# HOSTNAME controls the bind address; 0.0.0.0 is correct for Docker.
-# HOST is also accepted as alias via startup shell (HOST -> HOSTNAME fallback).
+# Next.js standalone binds to whatever HOSTNAME holds, and Docker fills that
+# variable with the container id whenever the image leaves it unset. The server
+# then listens on that one interface: reachable through a published port by
+# accident, unreachable anywhere the name does not resolve. Pinning it is what
+# lets a reverse proxy on the same network reach the container with no host
+# port published, and it is what the upstream `with-docker` example does.
 ENV HOSTNAME="0.0.0.0"
 ENV PORT="3000"
 EXPOSE 3000
@@ -54,7 +57,4 @@ COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/.next/standalon
 COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/.next/static ./apps/webview-ui/.next/static
 COPY --from=installer --chown=nextjs:nodejs /app/apps/webview-ui/public ./apps/webview-ui/public
 
-# HOST is an alias for HOSTNAME (common convention). Next.js standalone only
-# reads HOSTNAME, so map HOST -> HOSTNAME when HOSTNAME is not explicitly set.
-# This allows `HOST=0.0.0.0` or reverse-proxy setups without exposing a port.
-CMD ["sh", "-c", "HOSTNAME=${HOSTNAME:-${HOST:-0.0.0.0}} PORT=${PORT:-3000} node apps/webview-ui/server.js"]
+CMD ["node", "apps/webview-ui/server.js"]

--- a/apps/webview-ui/README.md
+++ b/apps/webview-ui/README.md
@@ -29,8 +29,6 @@ export RUSTRAK_API_URL="http://localhost:8080"
 pnpm dev
 ```
 
-## Docker
-
 ```bash
 docker pull rustrak/rustrak-ui
 docker run -d -p 3000:3000 \
@@ -38,12 +36,29 @@ docker run -d -p 3000:3000 \
   rustrak/rustrak-ui
 ```
 
+### Behind a reverse proxy (no port exposure)
+
+You don't need to expose a host port. Let the proxy route by host header
+and keep the container on the internal Docker network:
+
+```bash
+docker run -d --network rustrak \
+  -e HOSTNAME=0.0.0.0 \
+  -e RUSTRAK_API_URL=http://server:8080 \
+  rustrak/rustrak-ui
+```
+
+Or with docker-compose, remove the `ports` section from the `ui` service
+and put it behind Traefik/nginx/Caddy.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `RUSTRAK_API_URL` | Yes | - | Rustrak server URL |
-
+| `RUSTRAK_API_URL` | Yes | - | Rustrak server URL (e.g. `http://server:8080` internally, or `https://api.example.com` via proxy) |
+| `HOSTNAME` | No | `0.0.0.0` | Bind address for Next.js standalone server. `0.0.0.0` is correct inside Docker |
+| `HOST` | No | `0.0.0.0` | Alias for `HOSTNAME` (compatibility). If `HOSTNAME` is unset, `HOST` is used |
+| `PORT` | No | `3000` | Port the UI listens on inside the container |
 ## Tech Stack
 
 - **Framework**: Next.js 16 (App Router)

--- a/apps/webview-ui/README.md
+++ b/apps/webview-ui/README.md
@@ -29,6 +29,8 @@ export RUSTRAK_API_URL="http://localhost:8080"
 pnpm dev
 ```
 
+## Docker
+
 ```bash
 docker pull rustrak/rustrak-ui
 docker run -d -p 3000:3000 \
@@ -36,29 +38,34 @@ docker run -d -p 3000:3000 \
   rustrak/rustrak-ui
 ```
 
-### Behind a reverse proxy (no port exposure)
+### Behind a reverse proxy
 
-You don't need to expose a host port. Let the proxy route by host header
-and keep the container on the internal Docker network:
+The image binds to `0.0.0.0`, so a proxy on the same Docker network reaches it
+on port `3000` with nothing published to the host. Drop the `-p` and join the
+network the proxy is on:
 
 ```bash
-docker run -d --network rustrak \
-  -e HOSTNAME=0.0.0.0 \
+docker network create rustrak                       # once
+docker run -d --network rustrak --name ui \
   -e RUSTRAK_API_URL=http://server:8080 \
   rustrak/rustrak-ui
 ```
 
-Or with docker-compose, remove the `ports` section from the `ui` service
-and put it behind Traefik/nginx/Caddy.
+`RUSTRAK_API_URL` stays internal here. The dashboard calls the server
+server-side, so that request never leaves the network, and pointing it at your
+public domain breaks sign-in. With Compose, delete the `ports:` block from the
+`ui` service and route by host in Traefik, nginx or Caddy. The full setup,
+including the DSN, is in
+[Reverse proxy](https://rustrak.github.io/rustrak/configuration/production#reverse-proxy).
 
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `RUSTRAK_API_URL` | Yes | - | Rustrak server URL (e.g. `http://server:8080` internally, or `https://api.example.com` via proxy) |
-| `HOSTNAME` | No | `0.0.0.0` | Bind address for Next.js standalone server. `0.0.0.0` is correct inside Docker |
-| `HOST` | No | `0.0.0.0` | Alias for `HOSTNAME` (compatibility). If `HOSTNAME` is unset, `HOST` is used |
-| `PORT` | No | `3000` | Port the UI listens on inside the container |
+| `RUSTRAK_API_URL` | Yes | `http://localhost:8080` | Address the dashboard uses to reach the server. Always an internal one |
+| `PORT` | No | `3000` | Port the dashboard listens on inside the container |
+| `HOSTNAME` | No | `0.0.0.0` | TCP bind address. Already correct in the image, and not something to forward from the host environment |
+
 ## Tech Stack
 
 - **Framework**: Next.js 16 (App Router)

--- a/apps/webview-ui/src/__tests__/architecture/docker-bind-address.test.ts
+++ b/apps/webview-ui/src/__tests__/architecture/docker-bind-address.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The image pins the dashboard's bind address, and nothing hands it one from
+ * the environment it was deployed from.
+ *
+ * Both halves are the same bug seen from opposite sides. A Next.js standalone
+ * server binds to whatever `HOSTNAME` holds, and Docker fills `HOSTNAME` with
+ * the container id on any image that leaves it unset -- so an image that does
+ * not pin it listens on one interface whose name resolves nowhere else. That
+ * is what `ENV HOSTNAME="0.0.0.0"` fixes, and it is what lets a reverse proxy
+ * reach the container with no host port published.
+ *
+ * Compose has the mirror-image problem. `HOSTNAME=${HOSTNAME:-0.0.0.0}` reads
+ * as a courteous default and is a live grenade: every process that runs inside
+ * a container already exports `HOSTNAME`, so a CI runner, Portainer or any
+ * dockerised deploy tool passes its own container id down into the dashboard,
+ * which then dies on `ENOTFOUND` before serving a request. It breaks
+ * installations that use no proxy at all, which is why the rule is blanket
+ * rather than a warning in the docs.
+ *
+ * Neither half is reachable from a normal test -- one is an image, the other a
+ * deployment file -- so this reads them as text, the way every other rule in
+ * this folder reads source.
+ */
+
+const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+);
+
+const read = (path: string) => readFileSync(join(repoRoot, path), 'utf8');
+
+/** Every Compose file shipped as a starting point for an installation. */
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.dev.yml'];
+
+/**
+ * `HOST` is here beside `HOSTNAME` for the server, whose `HOST` defaults to
+ * `0.0.0.0` in `config.rs` already. Forwarding it buys nothing and carries the
+ * same shape of risk, so neither name belongs in a Compose file.
+ */
+const BIND_ADDRESS_KEY = /^\s*-?\s*(HOSTNAME|HOST)\s*[=:]/;
+
+describe('dashboard bind address', () => {
+  it('is pinned to 0.0.0.0 by the image', () => {
+    const dockerfile = read('apps/webview-ui/Dockerfile');
+
+    expect(dockerfile).toMatch(/^ENV HOSTNAME="0\.0\.0\.0"$/m);
+  });
+
+  it('is not resolved at startup from a HOST alias', () => {
+    // Next.js standalone reads `HOSTNAME` and only `HOSTNAME`. A `CMD` that
+    // maps `HOST` onto it cannot work under the `ENV` above, which always
+    // wins, so the alias is documentation for behaviour that does not exist.
+    const dockerfile = read('apps/webview-ui/Dockerfile');
+
+    expect(dockerfile).not.toMatch(/\$\{HOST[:\-}]/);
+  });
+
+  it.each(COMPOSE_FILES)(
+    'is not forwarded from the ambient environment in %s',
+    (file) => {
+      const forwarded = read(file)
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .filter((line) => BIND_ADDRESS_KEY.test(line));
+
+      expect(forwarded).toEqual([]);
+    },
+  );
+});

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,13 +22,15 @@ services:
       args:
         FEATURES: postgres
     ports:
-      - "8080:8080"
+      - "${SERVER_PORT:-8080}:8080"
     environment:
+      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=info
       - DATABASE_URL=postgres://rustrak:rustrak@postgres:5432/rustrak
-      - SESSION_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      - SESSION_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - CREATE_SUPERUSER=admin@admin.com:password123
+      - PUBLIC_URL=${PUBLIC_URL:-}
     volumes:
       - sourcemaps_data:/data/sourcemaps
     depends_on:
@@ -40,12 +42,13 @@ services:
       context: .
       dockerfile: ./apps/webview-ui/Dockerfile
     ports:
-      - "3000:3000"
+      - "${UI_PORT:-3000}:3000"
     environment:
+      - HOSTNAME=${HOSTNAME:-0.0.0.0}
+      - PORT=3000
       - RUSTRAK_API_URL=http://server:8080
     depends_on:
       - server
-
 volumes:
   postgres_data:
   sourcemaps_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,13 +24,12 @@ services:
     ports:
       - "${SERVER_PORT:-8080}:8080"
     environment:
-      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=info
       - DATABASE_URL=postgres://rustrak:rustrak@postgres:5432/rustrak
-      - SESSION_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      - SESSION_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
       - CREATE_SUPERUSER=admin@admin.com:password123
-      - PUBLIC_URL=${PUBLIC_URL:-}
+      - PUBLIC_URL=${PUBLIC_URL:-http://localhost:${SERVER_PORT:-8080}}
     volumes:
       - sourcemaps_data:/data/sourcemaps
     depends_on:
@@ -44,11 +43,10 @@ services:
     ports:
       - "${UI_PORT:-3000}:3000"
     environment:
-      - HOSTNAME=${HOSTNAME:-0.0.0.0}
-      - PORT=3000
       - RUSTRAK_API_URL=http://server:8080
     depends_on:
       - server
+
 volumes:
   postgres_data:
   sourcemaps_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,20 @@ services:
 
   server:
     image: rustrak/rustrak-server:latest
+    # Expose via host port mapping (e.g. SERVER_PORT=8080 -> 8080:8080).
+    # When behind a reverse proxy (Traefik, nginx, Caddy) you can remove `ports`
+    # and let the proxy route by container name / host header — no port exposure needed.
     ports:
-      - "${SERVER_PORT}:8080"
+      - "${SERVER_PORT:-8080}:8080"
     environment:
+      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=${RUST_LOG}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
       - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+      # Public URL shown in DSN — set to your reverse-proxy host to avoid exposing :8080
+      # e.g. PUBLIC_URL=https://rustrak.example.com
       - PUBLIC_URL=${PUBLIC_URL:-}
       - SOURCEMAP_STORAGE_PATH=/data/sourcemaps
     volumes:
@@ -35,9 +41,13 @@ services:
 
   ui:
     image: rustrak/rustrak-ui:latest
+    # By default exposes ${UI_PORT:-3000}:3000. Behind a reverse proxy you can
+    # remove `ports` and route by host (e.g. ui.example.com) — no port needed.
     ports:
-      - "${UI_PORT}:3000"
+      - "${UI_PORT:-3000}:3000"
     environment:
+      - HOSTNAME=${HOSTNAME:-0.0.0.0}
+      - PORT=3000
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
     depends_on:
       - server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,20 +16,19 @@ services:
 
   server:
     image: rustrak/rustrak-server:latest
-    # Expose via host port mapping (e.g. SERVER_PORT=8080 -> 8080:8080).
-    # When behind a reverse proxy (Traefik, nginx, Caddy) you can remove `ports`
-    # and let the proxy route by container name / host header — no port exposure needed.
+    # Behind a reverse proxy on the same Docker network, delete this `ports`
+    # block: the proxy reaches the container on 8080 and nothing needs a host
+    # port. Full setup: https://rustrak.github.io/rustrak/configuration/production#reverse-proxy
     ports:
       - "${SERVER_PORT:-8080}:8080"
     environment:
-      - HOST=${HOST:-0.0.0.0}
       - PORT=8080
       - RUST_LOG=${RUST_LOG}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
       - CREATE_SUPERUSER=${CREATE_SUPERUSER}
-      # Public URL shown in DSN — set to your reverse-proxy host to avoid exposing :8080
-      # e.g. PUBLIC_URL=https://rustrak.example.com
+      # The host your SDKs will send events to, e.g. https://rustrak.example.com.
+      # Without it the DSN carries the bind address, which nothing can reach.
       - PUBLIC_URL=${PUBLIC_URL:-}
       - SOURCEMAP_STORAGE_PATH=/data/sourcemaps
     volumes:
@@ -41,13 +40,13 @@ services:
 
   ui:
     image: rustrak/rustrak-ui:latest
-    # By default exposes ${UI_PORT:-3000}:3000. Behind a reverse proxy you can
-    # remove `ports` and route by host (e.g. ui.example.com) — no port needed.
+    # Same as the server: delete this `ports` block when a reverse proxy routes
+    # to the container directly.
     ports:
       - "${UI_PORT:-3000}:3000"
     environment:
-      - HOSTNAME=${HOSTNAME:-0.0.0.0}
-      - PORT=3000
+      # Always the internal address of the server, never the public one: this
+      # request never leaves the Docker network.
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
     depends_on:
       - server


### PR DESCRIPTION
## What changed

Allow running `webview-ui` and `server` behind a reverse proxy **without exposing a host port** — routing by host header.

### webview-ui
- `Dockerfile` now reads `HOSTNAME`/`PORT` (Next.js standalone) with fallback `HOST -> HOSTNAME` for Docker convention compatibility
- `ENV HOSTNAME=0.0.0.0` + `EXPOSE 3000` + `CMD sh -c 'HOSTNAME=${HOSTNAME:-${HOST:-0.0.0.0}}'` — supports both `HOST=0.0.0.0` and `HOSTNAME`
- Previously setting `HOST` had no effect (Next.js only reads `HOSTNAME`)

### Compose
- `docker-compose.yml` / `docker-compose.dev.yml`: `ports: ${UI_PORT:-3000}:3000` and `${SERVER_PORT:-8080}:8080` with defaults
- `ui` exposes `HOSTNAME=${HOSTNAME:-0.0.0.0}` and `PORT=3000`; `server` exposes `HOST` and `PUBLIC_URL`
- Comments explain removing `ports` when behind Traefik/nginx/Caddy

### Docs
- `environment.mdx`: new `HOSTNAME / PORT (dashboard)` section with `networks: [proxy]` example and note about portless DSN via `PUBLIC_URL`
- `installation.mdx`: updated compose + `.env` with `HOST`/`HOSTNAME`/`PUBLIC_URL` and reverse-proxy callout
- `webview-ui/README.md`: `HOSTNAME/HOST/PORT` table + `docker run --network rustrak` example without `-p`

## Why

Currently `${UI_PORT}:3000` and `${SERVER_PORT}:8080` must be exposed even when the proxy already routes by host. This prevents setups with an internal proxy network where ui/server should not have a host port. With `PUBLIC_URL=https://rustrak.example.com` the DSN becomes `https://<key>@rustrak.example.com/<project>` without `:8080`.

## How to test

```bash
# 1. Normal dev (with ports)
docker compose -f docker-compose.dev.yml up -d

# 2. Proxy (without ports)
# remove ports from ui/server, run behind Traefik with host=ui.example.com labels
# verify DSN has no :8080 when PUBLIC_URL is set
```

## Checklist
- [x] Dockerfile builds (ENV + CMD)
- [x] Docs updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable server and dashboard ports and bind hosts for Docker and Docker Compose deployments.
  * Added support for `PUBLIC_URL` to simplify reverse-proxy configurations.
  * Documented `HOSTNAME`, `HOST`, and `PORT` settings, including defaults and fallback behavior.
  * Added guidance for running deployments behind a reverse proxy without exposing container ports.

* **Documentation**
  * Expanded installation and deployment guidance for Docker, Compose, and reverse-proxy setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->